### PR TITLE
Here's what I've been working on:

### DIFF
--- a/wp-content/themes/mobooking/assets/css/reset.css
+++ b/wp-content/themes/mobooking/assets/css/reset.css
@@ -1,0 +1,51 @@
+/* Basic CSS Reset */
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+    display: block;
+}
+body {
+    line-height: 1;
+}
+ol, ul {
+    list-style: none;
+}
+blockquote, q {
+    quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+    content: '';
+    content: none;
+}
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+/* Basic box-sizing */
+html {
+    box-sizing: border-box;
+}
+*, *:before, *:after {
+    box-sizing: inherit;
+}

--- a/wp-content/themes/mobooking/functions.php
+++ b/wp-content/themes/mobooking/functions.php
@@ -71,7 +71,11 @@ add_action( 'after_setup_theme', 'mobooking_setup' );
 
 // Enqueue scripts and styles.
 function mobooking_scripts() {
-    wp_enqueue_style( 'mobooking-style', get_stylesheet_uri(), array(), MOBOOKING_VERSION );
+    // Enqueue CSS Reset first
+    wp_enqueue_style( 'mobooking-reset', MOBOOKING_THEME_URI . 'assets/css/reset.css', array(), MOBOOKING_VERSION );
+
+    // Enqueue main stylesheet, making it dependent on the reset
+    wp_enqueue_style( 'mobooking-style', get_stylesheet_uri(), array('mobooking-reset'), MOBOOKING_VERSION );
     // wp_enqueue_script( 'mobooking-navigation', MOBOOKING_THEME_URI . 'js/navigation.js', array(), MOBOOKING_VERSION, true );
 
     if ( is_page_template( 'page-login.php' ) || is_page_template('page-register.php') ) { // Assuming page-register.php for future


### PR DESCRIPTION
- I verified that all custom database tables correctly use the 'wp_mobooking_' prefixing scheme as defined in `classes/Database.php`. No changes were required as it was already correctly implemented.
- I added a basic CSS reset (`assets/css/reset.css`) to reduce browser inconsistencies in default element styling.
- I enqueued `reset.css` in `functions.php` to load before the main theme stylesheet.