### PR TITLE
Fix: Improve AJAX error handling and logging for service details

### DIFF
--- a/assets/js/dashboard-services.js
+++ b/assets/js/dashboard-services.js
@@ -275,8 +275,28 @@ jQuery(document).ready(function($) {
                 }
             },
             error: function(jqXHR, textStatus, errorThrown) {
-                alert(mobooking_services_params.i18n.error_ajax || 'AJAX error fetching service details. Check console for more info.');
-                console.error('AJAX error fetching service details:', textStatus, errorThrown, jqXHR.responseText);
+                let serverMessage = '';
+                if (jqXHR.responseText) {
+                    try {
+                        const response = JSON.parse(jqXHR.responseText);
+                        if (response && response.data && response.data.message) {
+                            serverMessage = 'Server said: ' + response.data.message;
+                        } else if (jqXHR.responseText.length < 200) { // Avoid showing huge HTML error pages in alert
+                            serverMessage = 'Server response: ' + jqXHR.responseText;
+                        }
+                    } catch (e) {
+                        // responseText was not JSON, might be HTML or plain text
+                        if (jqXHR.responseText.length < 200) {
+                             serverMessage = 'Server response: ' + jqXHR.responseText.substring(0, 100) + '...';
+                        } else {
+                             serverMessage = 'Server returned an unexpected response (see console for full details).';
+                        }
+                    }
+                }
+                const alertMessage = (mobooking_services_params.i18n.error_ajax || 'AJAX error fetching service details.') +
+                                     ` Status: ${jqXHR.status}. ${serverMessage} Check console for full details.`;
+                alert(alertMessage);
+                console.error('AJAX error fetching service details. Status:', jqXHR.status, 'Error:', errorThrown, 'Response:', jqXHR.responseText, 'Full XHR:', jqXHR);
             },
             complete: function() {
                 $editButton.prop('disabled', false).text(originalButtonText);


### PR DESCRIPTION
This commit addresses an "AJAX error fetching service details" by:

1.  Enhancing client-side error handling in `assets/js/dashboard-services.js`:
    - The error callback for the `mobooking_get_service_details` AJAX request now logs more detailed information to the console (jqXHR status, responseText, full XHR object).
    - It also displays a more informative alert message to you, including server-provided details if available and concise.

2.  Improving server-side logging in `classes/Services.php`:
    - Added `error_log` statements within the `handle_get_service_details_ajax` method to log incoming POST data, the service ID being processed, and the outcome of the `get_service` call.
    - Added `error_log` statements within the `get_service` method to log results of ownership verification, database queries, and option fetching.
    - Added more detailed logging for `WP_Error` cases within `handle_get_service_details_ajax`.

These changes aim to provide better diagnostics for any errors occurring during the fetching of service details, making it easier to identify the root cause and improving the feedback provided to you or the developer. A general review of AJAX handling was also performed, with potential future enhancements noted for JS error consistency.