### PR TITLE
Fix form container visibility and apply ShadCN UI styling

### DIFF
--- a/assets/css/dashboard-service-edit.css
+++ b/assets/css/dashboard-service-edit.css
@@ -1,270 +1,319 @@
-/* Styles for MoBooking Service Edit Page */
+/* Styles for MoBooking Service Edit Page - ShadCN UI Aesthetic */
 
-/* General Form Styles */
-#mobooking-service-form input[type="text"],
-#mobooking-service-form input[type="number"],
-#mobooking-service-form input[type="url"],
-#mobooking-service-form textarea,
-#mobooking-service-form select {
-    border: 1px solid #ccc;
-    padding: 8px 10px;
-    border-radius: 4px;
-    box-sizing: border-box;
-    width: 100%; /* Default to full width within their container */
-    margin-bottom: 5px; /* Consistent bottom margin for inputs */
-    font-family: sans-serif;
+/* A. Main Container */
+#mobooking-service-form-container {
+    display: block; /* Ensure visibility */
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb; /* Light gray border */
+    border-radius: 0.5rem;
+    padding: 2rem; /* Generous padding */
+    max-width: 700px; /* Already set inline, but good to have in CSS if inline is removed */
+    margin-top: 20px; /* Existing */
+    /* margin-left: auto; margin-right: auto; /* Uncomment if centering is needed */
 }
 
-#mobooking-service-form p {
-    margin-bottom: 15px; /* Consistent spacing for paragraphs holding form elements */
+/* E. Headings and General Text (Applied early for broad elements) */
+#mobooking-service-form-container h1,
+#mobooking-service-form-container h2,
+#mobooking-service-form-container h3 {
+    font-family: inherit; /* Assuming WP dashboard provides a good sans-serif */
+    color: #111827; /* Very dark gray/black */
+    margin-bottom: 1rem; /* Consistent bottom margin for headings */
 }
 
-#mobooking-service-form label {
-    font-weight: bold;
-    display: inline-block;
-    margin-bottom: 4px; /* Space between label and input */
+/* Page Title (assuming it's outside the form container but styled similarly) */
+.wrap.mobooking-service-edit-page > h1#mobooking-service-edit-page-title {
+    font-size: 1.875rem; /* Larger for page title */
+    font-weight: 600;
+    color: #111827;
+    margin-bottom: 1.5rem;
 }
 
-#mobooking-service-form input[type="text"]:focus,
-#mobooking-service-form input[type="number"]:focus,
-#mobooking-service-form input[type="url"]:focus,
-#mobooking-service-form textarea:focus,
-#mobooking-service-form select:focus {
-    border-color: #007cba; /* WordPress admin blue */
-    box-shadow: 0 0 0 1px #007cba;
-    outline: 1px solid transparent; /* Replace default outline */
+#mobooking-service-form-container #mobooking-service-form-title { /* If an H2 title exists within the form container */
+    font-size: 1.5rem; /* Example if there's a title inside the card */
+    font-weight: 600;
 }
 
-#mobooking-service-form .widefat { /* This class might be redundant if all inputs are 100% */
+#mobooking-service-options-section h3 { /* "Service Options" title */
+    font-size: 1.25rem; /* Slightly larger than regular sub-labels */
+    font-weight: 600;
+    color: #111827;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+
+/* B. General Form Elements */
+#mobooking-service-form-container input[type="text"],
+#mobooking-service-form-container input[type="number"],
+#mobooking-service-form-container input[type="url"],
+#mobooking-service-form-container textarea,
+#mobooking-service-form-container select {
+    border: 1px solid #d1d5db; /* ShadCN input border */
+    border-radius: 0.375rem;
+    padding: 0.625rem 0.875rem; /* Adjusted padding */
+    font-size: 0.9rem; /* Adjusted font size */
     width: 100%;
+    box-sizing: border-box;
+    margin-bottom: 0; /* Parent p will handle margin */
+    background-color: #ffffff;
+    color: #111827;
+    line-height: 1.5;
 }
 
-/* Service Options Section */
+#mobooking-service-form-container input[type="text"]:focus,
+#mobooking-service-form-container input[type="number"]:focus,
+#mobooking-service-form-container input[type="url"]:focus,
+#mobooking-service-form-container textarea:focus,
+#mobooking-service-form-container select:focus {
+    border-color: #2563eb; /* ShadCN focus blue */
+    box-shadow: 0 0 0 1px #2563eb;
+    outline: none;
+}
+
+#mobooking-service-form-container p {
+    margin-bottom: 1.25rem; /* Spacing for form element groups */
+}
+#mobooking-service-form-container p:last-of-type {
+    margin-bottom: 1.5rem; /* More space before main action buttons */
+}
+
+
+#mobooking-service-form-container label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 0.375rem;
+    font-size: 0.875rem;
+    color: #374151; /* Dark gray text */
+}
+
+/* C. Buttons */
+#mobooking-service-form-container .button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 0.625rem 1.25rem; /* Adjusted padding */
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+    border: 1px solid transparent;
+    cursor: pointer;
+}
+
+#mobooking-service-form-container .button:focus-visible { /* Using focus-visible for better accessibility */
+    outline: 2px solid #3b82f6; /* ShadCN focus ring blue */
+    outline-offset: 2px;
+}
+
+#mobooking-service-form-container .button-primary {
+    background-color: #1f2937; /* ShadCN primary dark */
+    color: #ffffff;
+    border-color: #1f2937;
+}
+#mobooking-service-form-container .button-primary:hover {
+    background-color: #374151; /* Darker shade */
+}
+
+#mobooking-service-form-container .button:not(.button-primary):not(.button-link-delete) {
+    background-color: #ffffff;
+    color: #374151; /* Dark gray text */
+    border: 1px solid #d1d5db; /* Input border color */
+}
+#mobooking-service-form-container .button:not(.button-primary):not(.button-link-delete):hover {
+    background-color: #f3f4f6; /* Light gray hover */
+}
+
+#mobooking-service-form-container .button-link-delete {
+    color: #ef4444; /* Red for delete/destructive */
+    background-color: transparent;
+    border-color: transparent;
+    padding-left: 0.5rem; /* Less padding if only text/icon */
+    padding-right: 0.5rem;
+}
+#mobooking-service-form-container .button-link-delete:hover {
+    background-color: #fee2e2; /* Light red background */
+    color: #b91c1c; /* Darker red text */
+}
+
+/* D. Service Options Styling */
 #mobooking-service-options-section {
-    margin-top: 25px; /* Increased top margin */
-    padding-top: 15px;
-    border-top: 1px solid #ddd; /* Changed from dashed to solid */
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e5e7eb;
 }
 
-#mobooking-service-options-section h3 {
-    margin-bottom: 15px; /* More space below section title */
-    font-size: 1.2em; /* Slightly larger title */
-}
-
-/* Service Option Rows */
 .mobooking-service-option-row {
-    padding: 15px; /* Increased padding */
-    margin-top: 15px; /* Increased separation */
-    border: 1px solid #e0e0e0; /* Lightened border */
-    border-radius: 4px; /* Standardized radius */
-    background-color: #f9f9f9; /* Light background for differentiation */
-    display: flex; /* For drag handle alignment */
-    align-items: flex-start; /* Align items to the top for multi-line content */
-    gap: 10px; /* Gap for direct children, primarily for drag handle and main content */
+    background-color: #f9fafb; /* Slightly off-white */
+    border: 1px solid #e5e7eb;
+    border-radius: 0.375rem;
+    padding: 1.25rem; /* Adjusted padding */
+    margin-top: 1rem;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem; /* Space for drag handle */
 }
-
 .mobooking-service-option-row-content {
-    flex-grow: 1; /* Allow content to take remaining space */
+    flex-grow: 1;
 }
-
-
 .mobooking-service-option-row p {
-    margin-top: 0; /* Remove top margin for p inside option row if not needed */
-    margin-bottom: 10px; /* Consistent spacing for p tags inside option row */
+    margin-bottom: 0.75rem; /* Spacing within an option row */
 }
-.mobooking-service-option-row p:last-child {
-    margin-bottom: 0; /* No bottom margin for the last paragraph */
+.mobooking-service-option-row label { /* Labels within option rows */
+    font-size: 0.8rem; /* Slightly smaller for compactness */
+    color: #4b5563; /* Medium gray */
 }
-
-.mobooking-service-option-row label { /* More specific for labels within option rows */
-    font-weight: bold;
-    display: inline-block;
-    margin-bottom: 3px;
-}
-
-#mobooking-add-service-option-btn {
-    margin-top: 20px; /* More space above Add Option button */
+.mobooking-service-option-row input[type="text"],
+.mobooking-service-option-row input[type="number"],
+.mobooking-service-option-row textarea,
+.mobooking-service-option-row select {
+    font-size: 0.875rem; /* Consistent input font size */
+    padding: 0.5rem 0.75rem; /* Slightly smaller padding for inputs in options */
 }
 
-/* Custom Radio Button Styles for Option Type */
-.mobooking-option-type { /* The original select element */
-    display: none !important; /* Keep hidden as JS provides UI */
+
+.mobooking-option-drag-handle {
+    cursor: move;
+    font-size: 1.25rem;
+    color: #6b7280; /* Medium gray handle */
+    padding-top: 0.625rem; /* Align with first input */
+}
+
+.mobooking-service-option-row-placeholder {
+    height: 80px; /* Approximate height */
+    background-color: #eef2ff; /* Light indigo */
+    border: 2px dashed #a5b4fc; /* Indigo dashed border */
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    border-radius: 0.375rem;
+}
+
+.mobooking-option-type { /* Original select for option type */
+    display: none !important; /* JS handles this */
 }
 .mobooking-custom-radio-group {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
-    margin-bottom: 10px;
-    margin-top: 5px;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
 }
 .mobooking-custom-radio-label {
-    padding: 8px 14px; /* Increased padding */
-    border: 1px solid #ccc;
-    border-radius: 3px; /* Slightly less radius */
+    border: 1px solid #d1d5db;
+    background-color: #ffffff;
+    padding: 0.375rem 0.875rem; /* Adjusted padding */
+    border-radius: 0.375rem;
+    font-size: 0.8rem;
+    color: #374151;
     cursor: pointer;
-    font-size: 0.95em; /* Adjusted font size */
     transition: background-color 0.2s, border-color 0.2s, color 0.2s;
-    background-color: #f7f7f7; /* Lighter default */
-}
-.mobooking-custom-radio-label:hover {
-    background-color: #f0f0f0;
-    border-color: #999; /* Darker border on hover */
 }
 .mobooking-custom-radio-label.selected {
-    background-color: #007cba;
-    color: white;
-    border-color: #007cba;
+    background-color: #1f2937; /* Dark primary */
+    color: #ffffff;
+    border-color: #1f2937;
+}
+.mobooking-custom-radio-label:hover:not(.selected) {
+    background-color: #f3f4f6; /* Light gray hover */
 }
 
-/* Styles for Option Choices UI */
-.mobooking-option-values-field textarea { /* The original textarea for JSON */
-    display: none !important; /* Keep hidden */
+.mobooking-option-values-field textarea { /* Original textarea for choices JSON */
+    display: none !important; /* JS handles this */
 }
 .mobooking-choices-ui-container {
-    margin-top: 8px; /* Increased margin */
-    padding: 12px; /* Increased padding */
-    background-color: #fff; /* White background */
-    border: 1px solid #ddd;
-    border-radius: 3px;
+    padding: 0.75rem;
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.375rem;
+    margin-top: 0.5rem;
 }
 .mobooking-choices-list {
-    margin-bottom: 12px; /* Increased margin */
-    min-height: 25px; /* Slightly taller */
+    margin-bottom: 0.75rem;
+    min-height: 1.5rem;
 }
-.mobooking-add-choice-btn {
-    margin-top: 8px; /* Consistent margin */
+.mobooking-add-choice-btn { /* Button to add a new choice */
+    font-size: 0.8rem;
+    padding: 0.375rem 0.75rem;
 }
 
 .mobooking-choice-item {
+    background-color: #f9fafb; /* Off-white for choice items */
+    border: 1px solid #d1d5db;
+    padding: 0.625rem; /* Adjusted padding */
+    border-radius: 0.375rem;
     display: flex;
-    align-items: center; /* Vertically align items */
-    gap: 10px; /* Increased gap */
-    padding: 10px; /* Increased padding */
-    border: 1px solid #e5e5e5; /* Lighter border */
-    border-radius: 3px;
-    margin-bottom: 10px; /* Increased margin */
-    background-color: #fdfdfd; /* Very light background */
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
 }
 .mobooking-choice-item input[type="text"],
 .mobooking-choice-item input[type="number"] {
-    margin-bottom: 0 !important; /* Keep this to override general input margin */
+    font-size: 0.8rem; /* Smaller font for choice inputs */
+    padding: 0.375rem 0.5rem; /* Smaller padding */
+    margin-bottom: 0 !important;
 }
-.mobooking-choice-label { flex-grow: 1; }
-.mobooking-choice-value { flex-basis: 100px; } /* Adjusted basis */
-.mobooking-choice-price-adjust { flex-basis: 90px; } /* Adjusted basis */
-
 .mobooking-choice-drag-handle {
     cursor: move;
-    font-size: 18px; /* Larger handle */
-    color: #555; /* Darker color */
-    padding: 0 5px; /* Adjust padding */
+    font-size: 1rem;
+    color: #6b7280;
+    padding: 0 0.25rem;
 }
-.mobooking-remove-choice-btn {
-    color: #d63638; /* More prominent red */
-    text-decoration: none;
-    font-size: 20px; /* Slightly smaller for balance */
-    line-height: 1;
-    background: none;
-    border: none;
-    padding: 0 5px;
+.mobooking-remove-choice-btn { /* Tiny cross button for removing a choice */
+    color: #9ca3af; /* Lighter red/gray */
+    font-size: 1.25rem;
+    padding: 0 0.375rem;
 }
 .mobooking-remove-choice-btn:hover {
-    color: #a02020; /* Darker red on hover */
+    color: #ef4444; /* Red on hover */
+    background-color: transparent;
 }
-
-/* Placeholder for jQuery UI Sortable for Choices */
 .mobooking-choice-item-placeholder {
-    height: 48px; /* Adjust to match item height (padding + line height) */
-    background-color: #e6f7ff; /* Lighter blue */
-    border: 1px dashed #99cfff; /* Blue dashed border */
-    margin-bottom: 10px;
-    border-radius: 3px;
-    box-sizing: border-box;
+    height: 40px;
+    background-color: #eef2ff; /* Light indigo placeholder */
+    border: 1px dashed #a5b4fc;
+    margin-bottom: 0.5rem;
+    border-radius: 0.375rem;
 }
 
-/* Drag Handle and Placeholder for Service Options Reordering */
-.mobooking-option-drag-handle {
-    cursor: move;
-    font-size: 20px; /* Prominent handle */
-    color: #444;
-    padding-right: 10px; /* Space between handle and content */
-    padding-top: 12px; /* Align with first line of text */
-}
-
-.mobooking-service-option-row-placeholder {
-    height: 100px; /* Approximate height of an option row */
-    background-color: #f0f0f0;
-    border: 2px dashed #ccc;
-    margin-top: 15px;
-    margin-bottom: 15px;
-    border-radius: 4px;
-    box-sizing: border-box;
-}
-
-/* Feedback Messages */
-#mobooking-service-form-feedback.success {
-    color: #155724;
-    background-color: #d4edda;
-    border-color: #c3e6cb;
-    padding: 10px;
-    margin-top: 15px;
-    border-radius: 4px;
-    border: 1px solid;
-}
-
+/* Feedback Messages (already styled in previous CSS, ensure consistency or remove if global styles cover this) */
+#mobooking-service-form-feedback.success,
 #mobooking-service-form-feedback.error {
-    color: #721c24;
-    background-color: #f8d7da;
-    border-color: #f5c6cb;
-    padding: 10px;
-    margin-top: 15px;
-    border-radius: 4px;
-    border: 1px solid;
+    padding: 0.75rem 1rem;
+    margin-top: 1.25rem;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+}
+#mobooking-service-form-feedback.success {
+    color: #0f5132; background-color: #d1e7dd; border-color: #badbcc;
+}
+#mobooking-service-form-feedback.error {
+    color: #842029; background-color: #f8d7da; border-color: #f5c2c7;
 }
 
-/* Utility class for visually hidden elements that are still accessible to screen readers */
-.mobooking-visually-hidden {
-  position: absolute !important;
-  height: 1px; width: 1px;
-  overflow: hidden;
-  clip: rect(1px, 1px, 1px, px); /* IE6, IE7 */
-  white-space: nowrap; /* Keep from wrapping */
-}
-
-/* Ensure no !important is used where specificity can solve it */
-/* Example: if #mobooking-service-options-section had margin-top: 15px !important; */
-/* It's now: #mobooking-service-options-section { margin-top: 25px; ... } */
-/* All !important rules from the original inline style have been reviewed. */
-/* display: none !important; for .mobooking-option-type and textarea is kept as JS controls their visibility. */
-
-#mobooking-service-form .mobooking-service-option-row p label.inline-label {
-    font-weight: normal; /* For checkbox labels like "Required?" */
-    margin-left: 5px;
-}
-
-/* Ensure checkbox and its label are aligned */
-#mobooking-service-form .mobooking-service-option-row p input[type="checkbox"] {
+/* Checkbox alignment */
+#mobooking-service-form-container input[type="checkbox"] {
     width: auto; /* Override general input width */
-    margin-right: 5px;
+    margin-right: 0.5rem;
+    vertical-align: middle;
+    border-radius: 0.25rem; /* ShadCN checkbox radius */
+    border-color: #d1d5db;
+}
+#mobooking-service-form-container input[type="checkbox"]:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 1px #2563eb;
+}
+#mobooking-service-form-container .mobooking-service-option-row p label.inline-label { /* For "Required?" */
+    font-weight: normal;
+    font-size: 0.875rem;
+    margin-left: 0.25rem;
     vertical-align: middle;
 }
 
-#mobooking-service-form .mobooking-service-option-row p input[type="hidden"] {
-    display:none; /* Hidden inputs should not take space */
-}
-
-/* Adjustments for buttons within the form */
-#mobooking-service-form .button {
-    margin-right: 10px; /* Space between buttons like Save/Cancel */
-}
-#mobooking-service-form .button-link-delete {
-    color: #d63638;
-    text-decoration: none;
+hr {
     border: none;
-    background: none;
-    padding: 0;
-    cursor: pointer;
-}
-#mobooking-service-form .button-link-delete:hover {
-    color: #a02020;
+    height: 1px;
+    background-color: #e5e7eb; /* Light gray separator */
+    margin-top: 2rem;
+    margin-bottom: 1.5rem;
 }


### PR DESCRIPTION
This commit addresses your feedback regarding the service edit page:

1.  Ensures `#mobooking-service-form-container` is visible by default on `page-service-edit.php` by adding `display: block;` to its CSS rules.
2.  Implements a general styling overhaul in `assets/css/dashboard-service-edit.css` to give the service edit page a look and feel inspired by ShadCN UI. This includes:
    - Styling the main form container as a card.
    - Updating styles for input fields, textareas, and selects (borders, padding, focus states).
    - Redesigning buttons (primary, secondary, destructive) for a modern aesthetic.
    - Refining the appearance of service option rows, custom radio buttons for option types, and the choices UI to align with the new style.
    - Using a more muted color palette with clear accents and improving overall spacing and typography.

These changes aim to provide a cleaner, more modern, and visually appealing user interface for managing services.