### PR TITLE
Hotfix: Correct role constant names in functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -628,9 +628,9 @@ add_action( 'init', 'mobooking_ensure_business_owner_role_exists' );
 function mobooking_ensure_worker_roles_exist() {
     if (class_exists('MoBooking\Classes\Auth')) {
         $roles_to_check = array(
-            MoBooking\Classes\Auth::ROLE_MANAGER,
-            MoBooking\Classes\Auth::ROLE_STAFF,
-            MoBooking\Classes\Auth::ROLE_VIEWER
+            MoBooking\Classes\Auth::ROLE_WORKER_MANAGER,
+            MoBooking\Classes\Auth::ROLE_WORKER_STAFF,
+            MoBooking\Classes\Auth::ROLE_WORKER_VIEWER
         );
         $missing_roles = false;
         foreach ($roles_to_check as $role_name) {


### PR DESCRIPTION
This commit fixes a fatal error caused by undefined constants (MoBooking\Classes\Auth::ROLE_MANAGER, ::ROLE_STAFF, ::ROLE_VIEWER) in the `mobooking_ensure_roles_exist` function within `functions.php`.

The constants have been corrected to their proper definitions:
- `MoBooking\Classes\Auth::ROLE_WORKER_MANAGER`
- `MoBooking\Classes\Auth::ROLE_WORKER_STAFF`
- `MoBooking\Classes\Auth::ROLE_WORKER_VIEWER`

This ensures the function for checking and adding roles during the 'init' action works correctly without fatal errors.