### PR TITLE
Fix: Resolve fatal error and remove unused roles

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -644,7 +644,7 @@ function mobooking_ensure_worker_roles_exist() {
             MoBooking\Classes\Auth::add_worker_roles();
             add_action('admin_notices', function() {
                 echo '<div class="notice notice-success is-dismissible"><p>' .
-                     esc_html__('MoBooking: One or more worker user roles (Manager, Staff, Viewer) were missing and have been successfully re-created. Please refresh if you were assigning roles.', 'mobooking') .
+                     esc_html__('MoBooking: The "Worker Staff" user role was missing and has been successfully re-created. Please refresh if you were assigning roles.', 'mobooking') .
                      '</p></div>';
             });
         }


### PR DESCRIPTION
This commit addresses two main issues:

1.  **Fatal Error Fix:** Resolved a `Call to undefined function submit_button()` fatal error in `dashboard/page-workers.php`. The `submit_button()` calls were replaced with standard HTML `<input type="submit">` elements, which are appropriate for this front-end dashboard page context.

2.  **Remove Unused Roles:** The `Worker Manager` and `Worker Viewer` roles have been removed throughout the application to simplify the role system. Only `Worker Staff` remains as the designated role. Changes were made in:
    - `classes/Auth.php`: Removed constants, updated role creation/removal methods, and adjusted AJAX handlers.
    - `dashboard/page-workers.php`: Updated UI elements to reflect the single 'Worker Staff' role.
    - `classes/Admin/UserManagementPage.php`: Updated admin UI and internal logic for role display and management.
    - `functions.php`: Ensured role initialization logic now only pertains to 'Worker Staff'.