### PR TITLE
Hotfix: Correct undefined constant in mobooking_ensure_roles_exist

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -628,9 +628,7 @@ add_action( 'init', 'mobooking_ensure_business_owner_role_exists' );
 function mobooking_ensure_worker_roles_exist() {
     if (class_exists('MoBooking\Classes\Auth')) {
         $roles_to_check = array(
-            MoBooking\Classes\Auth::ROLE_WORKER_MANAGER,
-            MoBooking\Classes\Auth::ROLE_WORKER_STAFF,
-            MoBooking\Classes\Auth::ROLE_WORKER_VIEWER
+            MoBooking\Classes\Auth::ROLE_WORKER_STAFF
         );
         $missing_roles = false;
         foreach ($roles_to_check as $role_name) {


### PR DESCRIPTION
This commit fixes a fatal error in `functions.php` where the `mobooking_ensure_roles_exist` function was still referencing the deleted `MoBooking\Classes\Auth::ROLE_MANAGER` and `MoBooking\Classes\Auth::ROLE_VIEWER` constants within its `$roles_to_check` array.

The `$roles_to_check` array has been updated to only contain `MoBooking\Classes\Auth::ROLE_STAFF`, aligning it with the recent role simplification and resolving the fatal error on initialization.