### PR TITLE
Hotfix: Correct undefined role constant in dashboard sidebar

### DIFF
--- a/dashboard/sidebar.php
+++ b/dashboard/sidebar.php
@@ -16,9 +16,7 @@ if ( $current_user_id > 0 ) {
     if ( $user ) {
         $mobooking_role_keys = [
             \MoBooking\Classes\Auth::ROLE_BUSINESS_OWNER,
-            \MoBooking\Classes\Auth::ROLE_WORKER_MANAGER,
             \MoBooking\Classes\Auth::ROLE_WORKER_STAFF,
-            \MoBooking\Classes\Auth::ROLE_WORKER_VIEWER,
         ];
 
         $all_roles = wp_roles(); // Get all role objects, which include names


### PR DESCRIPTION
This commit fixes a fatal error in `dashboard/sidebar.php` where the `$mobooking_role_keys` array was still referencing deleted role constants (`ROLE_WORKER_MANAGER`, `ROLE_WORKER_VIEWER`).

The array has been updated to only include the currently defined `MoBooking\Classes\Auth::ROLE_BUSINESS_OWNER` and
`MoBooking\Classes\Auth::ROLE_WORKER_STAFF` constants.

This resolves the fatal error and ensures the sidebar correctly reflects the active role structure.