### PR TITLE
Hotfix: Correct PHP syntax error in dashboard/page-workers.php

### DIFF
--- a/dashboard/page-workers.php
+++ b/dashboard/page-workers.php
@@ -144,7 +144,6 @@ $all_worker_roles = [
             <tbody>
                 <?php foreach ( $workers as $worker ) : ?>
                     <?php
-                    <?php
                     // $worker_mobooking_roles_display = []; // Keep for potential future if multiple roles come back
                     $current_worker_role_name = __('N/A', 'mobooking');
                     $current_worker_role_key = ''; // Keep this to ensure 'Staff' is selected in dropdown if they have it.


### PR DESCRIPTION
This commit fixes a PHP parse error (syntax error, unexpected token '<') in `dashboard/page-workers.php`. The error was caused by a redundant, nested `<?php` opening tag within a PHP block inside a loop.

The superfluous tag has been removed, ensuring the PHP code is parsed correctly.