### PR TITLE
Fix: Ensure jQuery is loaded on dashboard pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -301,6 +301,10 @@ add_filter( 'template_include', 'mobooking_dashboard_template_include', 99 );
 
 // New function to handle dashboard script enqueuing
 function mobooking_enqueue_dashboard_scripts($current_page_slug) {
+    // Ensure jQuery is always available for dashboard pages that might use it directly
+    // or have inline scripts depending on it (like page-workers.php).
+    wp_enqueue_script('jquery');
+
     $user_id = get_current_user_id();
     $currency_code = 'USD'; // Default
     $currency_symbol = '$';


### PR DESCRIPTION
Resolves 'jQuery is not defined' error on the Workers page (and potentially other dashboard pages with inline jQuery) by explicitly enqueuing 'jquery' in the `mobooking_enqueue_dashboard_scripts` function.

This ensures that jQuery is available before any inline scripts or other enqueued scripts that depend on it are executed on dashboard pages.