### PR TITLE
Refactor: Improve modal display logic for Availability page

### DIFF
--- a/assets/js/dashboard-availability.js
+++ b/assets/js/dashboard-availability.js
@@ -85,13 +85,15 @@ jQuery(document).ready(function($) {
             $recurringSlotModalTitle.text(i18n.add_recurring_slot || 'Add Recurring Slot');
             $('#recurring-slot-id').val('');
         }
-        $recurringSlotModal.show();
-        $recurringSlotModalBackdrop.show();
+        // CSS now handles display via .active class
+        $recurringSlotModal.addClass('active');
+        $recurringSlotModalBackdrop.addClass('active');
     }
 
     function closeRecurringSlotModal() {
-        $recurringSlotModal.hide();
-        $recurringSlotModalBackdrop.hide();
+        // CSS now handles display via .active class
+        $recurringSlotModal.removeClass('active');
+        $recurringSlotModalBackdrop.removeClass('active');
     }
 
     function renderRecurringSlots(slots) {

--- a/dashboard/page-availability.php
+++ b/dashboard/page-availability.php
@@ -90,7 +90,7 @@ if ( ! current_user_can( \MoBooking\Classes\Auth::CAP_MANAGE_AVAILABILITY ) ) {
     </div>
 
     <!-- Modal for Adding/Editing Recurring Slot -->
-    <div id="mobooking-recurring-slot-modal" class="mobooking-modal" style="display:none;">
+    <div id="mobooking-recurring-slot-modal" class="mobooking-modal">
         <div class="mobooking-modal-content">
             <h3 id="recurring-slot-modal-title"><?php esc_html_e('Add Recurring Slot', 'mobooking'); ?></h3>
             <form id="mobooking-recurring-slot-form">
@@ -133,6 +133,6 @@ if ( ! current_user_can( \MoBooking\Classes\Auth::CAP_MANAGE_AVAILABILITY ) ) {
             </form>
         </div>
     </div>
-    <div id="mobooking-recurring-slot-modal-backdrop" class="mobooking-modal-backdrop" style="display:none;"></div>
+    <div id="mobooking-recurring-slot-modal-backdrop" class="mobooking-modal-backdrop"></div>
 
 </div>

--- a/style.css
+++ b/style.css
@@ -1435,6 +1435,7 @@ span.mobooking-menu-icon {
 
 /* Modal Styles (ShadCN inspired: card-like) */
 .mobooking-modal-backdrop {
+  display: none; /* Initially hidden */
   position: fixed;
   top: 0;
   left: 0;
@@ -1443,15 +1444,17 @@ span.mobooking-menu-icon {
   background-color: hsl(0 0% 0% / 0.6); /* Darker backdrop */
   z-index: 1000; /* Below modal, above content */
   opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.2s ease, visibility 0.2s ease;
+  /* visibility: hidden;  Visibility transition isn't smooth with display none/block */
+  transition: opacity 0.2s ease;
 }
 .mobooking-modal-backdrop.active {
+  display: block; /* Show */
   opacity: 1;
-  visibility: visible;
+  /* visibility: visible; */
 }
 
 .mobooking-modal {
+  display: none; /* Initially hidden */
   position: fixed;
   top: 50%;
   left: 50%;
@@ -1464,12 +1467,13 @@ span.mobooking-menu-icon {
   width: 90%;
   max-width: 480px; /* Slightly narrower */
   opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+  /* visibility: hidden; */
+  transition: opacity 0.2s ease, transform 0.2s ease;
 }
 .mobooking-modal.active {
+  display: block; /* Show */
   opacity: 1;
-  visibility: visible;
+  /* visibility: visible; */
   transform: translate(-50%, -50%) scale(1);
 }
 


### PR DESCRIPTION
- Remove inline 'display:none' styles from modal HTML elements.
- Update CSS to control modal display (none/block) via '.active' class, alongside existing opacity/transform transitions.
- Simplify JavaScript for modal open/close to only toggle the '.active' class, relying on CSS for display and animation.

This ensures a cleaner separation of concerns for modal visibility and transitions. Full CRUD functionality for availability remains intact and secured by CAP_MANAGE_AVAILABILITY.