### PR TITLE
Feat: Add in-modal errors and recurring day-off toggle

### DIFF
--- a/dashboard/page-availability.php
+++ b/dashboard/page-availability.php
@@ -19,16 +19,17 @@ if ( ! current_user_can( \MoBooking\Classes\Auth::CAP_MANAGE_AVAILABILITY ) ) {
     <!-- Recurring Weekly Availability Section -->
     <div class="mobooking-section">
         <h2><?php esc_html_e('Recurring Weekly Schedule', 'mobooking'); ?></h2>
-        <p><?php esc_html_e('Set your standard availability for each day of the week. These are your default hours unless overridden by a specific date setting below.', 'mobooking'); ?></p>
+        <p><?php esc_html_e('Set your standard availability for each day of the week. These are your default hours unless overridden by a specific date setting below. You can mark entire days as off, or add specific time slots.', 'mobooking'); ?></p>
 
         <div id="recurring-slots-container">
-            <!-- JS will populate this -->
+            <!-- JS will populate this with days and their slots/toggles -->
             <p><?php esc_html_e('Loading recurring schedule...', 'mobooking'); ?></p>
         </div>
 
-        <button type="button" id="mobooking-add-recurring-slot-btn" class="button button-primary">
-            <span class="dashicons dashicons-plus-alt2" style="margin-top:3px;"></span> <?php esc_html_e('Add Recurring Slot', 'mobooking'); ?>
+        <button type="button" id="mobooking-add-recurring-slot-btn" class="button button-primary" style="margin-top: 15px;">
+            <span class="dashicons dashicons-plus-alt2" style="margin-top:3px;"></span> <?php esc_html_e('Add New Time Slot', 'mobooking'); ?>
         </button>
+        <p class="description"><?php esc_html_e('Use the "Add New Time Slot" button to add specific working hours to a day. To mark an entire day as off or on, use the toggles that appear next to each day above.', 'mobooking'); ?></p>
     </div>
 
     <!-- Specific Date Overrides Section -->
@@ -93,6 +94,7 @@ if ( ! current_user_can( \MoBooking\Classes\Auth::CAP_MANAGE_AVAILABILITY ) ) {
     <div id="mobooking-recurring-slot-modal" class="mobooking-modal">
         <div class="mobooking-modal-content">
             <h3 id="recurring-slot-modal-title"><?php esc_html_e('Add Recurring Slot', 'mobooking'); ?></h3>
+            <div id="mobooking-recurring-slot-modal-error" class="mobooking-notice notice-error" style="display:none; margin-bottom: 15px;"></div>
             <form id="mobooking-recurring-slot-form">
                 <input type="hidden" id="recurring-slot-id" name="slot_id">
                 <div class="form-field">

--- a/functions.php
+++ b/functions.php
@@ -576,6 +576,15 @@ function mobooking_enqueue_dashboard_scripts($current_page_slug) {
             'confirm_delete_override' => __("Are you sure you want to delete the override for this date?", 'mobooking'),
             'error_no_override_to_delete' => __("No override selected to delete.", 'mobooking'),
             'error_deleting_override' => __("Error deleting override.", 'mobooking'),
+            'capacity_must_be_positive' => __("Capacity must be a positive number.", "mobooking"),
+            'mark_day_off' => __('Mark as Day Off', 'mobooking'),
+            'set_as_working_day' => __('Set as Working Day', 'mobooking'),
+            'day_marked_as_off' => __('This day is marked as off.', 'mobooking'),
+            'no_slots_add_some' => __('No time slots. Add some below.', 'mobooking'),
+            'no_active_slots_for_working_day' => __('No active slots for this working day. Add some or edit existing ones.', 'mobooking'),
+            'confirm_mark_day_off' => __('Are you sure you want to mark this day as off? All existing slots for this day will be deactivated.', 'mobooking'),
+            'confirm_set_working_day' => __('Are you sure you want to set this as a working day? You will need to add or activate time slots.', 'mobooking'),
+            'error_updating_day_status' => __('Error updating day status.', 'mobooking'),
         ];
         $availability_params = array_merge($dashboard_params, ['i18n' => $availability_i18n_strings]);
         wp_localize_script('mobooking-dashboard-availability', 'mobooking_availability_params', $availability_params);

--- a/style.css
+++ b/style.css
@@ -1322,8 +1322,16 @@ span.mobooking-menu-icon {
 .recurring-day-group h4 {
   font-size: 1.125rem; /* h5 equivalent */
   font-weight: 600;
-  margin-bottom: 0.75rem;
+  /* margin-bottom: 0.75rem; Remove bottom margin as it's part of flex now */
   color: hsl(222.2 84% 4.9%);
+  margin: 0; /* Reset margin for flex item */
+}
+
+.recurring-day-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
 }
 
 .recurring-slots-list {


### PR DESCRIPTION
- Implement in-modal error message display for the recurring slot form.
  - Client-side validation errors are now shown directly in the modal.
  - Server-side errors from saving a recurring slot are also shown in the modal.
- Add 'Recurring Day Off' functionality:
  - Users can now toggle an entire recurring day of the week (e.g., 'every Monday') as off or as a working day.
  - Marking a day as off deactivates all existing recurring slots for that day for the user.
  - Marking as a working day allows slots to be added/activated (existing slots remain inactive until explicitly managed).
  - Updated UI in the recurring schedule section to include these toggles.
  - Added necessary backend logic in Availability.php and JS handlers in dashboard-availability.js.
  - Included new i18n strings for UI elements and messages.