### PR TITLE
Refactor Bookings page to use table view and separate details page

### DIFF
--- a/assets/css/dashboard-bookings-responsive.css
+++ b/assets/css/dashboard-bookings-responsive.css
@@ -1,29 +1,26 @@
 /*
 ==========================================================================
-General Page & ShadCN-like Card Styling
+General Page & Common Card Styling (e.g., for Filters, Single Page Sections)
 ==========================================================================
 */
-
-/* Apply a base font stack similar to WordPress admin for consistency, can be overridden */
-body.wp-admin #wpbody-content .mobooking-bookings-page-wrapper {
+body.wp-admin #wpbody-content .mobooking-bookings-page-wrapper,
+body.wp-admin #wpbody-content .mobooking-single-booking-page-wrapper {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-    font-size: 14px; /* Consistent base font size */
-    background-color: #f0f0f0; /* Light gray background for the page, typical in modern UIs */
-    padding: 20px;
+    font-size: 14px;
 }
 
-.mobooking-bookings-page-wrapper {
-    max-width: 1600px; /* Max width for larger screens */
-    margin: 0 auto; /* Center the content */
-    padding: 15px; /* Padding around the page content */
-    background-color: var(--wp-admin-theme-color-fresh, #f0f2f5); /* Match WP admin bg or a neutral one */
+.mobooking-bookings-page-wrapper,
+.mobooking-single-booking-page-wrapper {
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 1px 15px 15px 15px;
 }
 
 .mobooking-card {
     background-color: #ffffff;
-    border: 1px solid #e2e8f0; /* Softer border color */
-    border-radius: 0.5rem; /* shadcn uses 0.5rem for cards */
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.03), 0 1px 2px 0 rgba(0, 0, 0, 0.02); /* Subtle shadow */
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.03), 0 1px 2px 0 rgba(0, 0, 0, 0.02);
     margin-bottom: 1.5rem;
     padding: 1.5rem;
 }
@@ -39,35 +36,38 @@ body.wp-admin #wpbody-content .mobooking-bookings-page-wrapper {
 
 .mobooking-card-header h3 {
     margin: 0;
-    font-size: 1.125rem; /* 18px */
+    font-size: 1.125rem;
     font-weight: 600;
     line-height: 1.2;
 }
 
 .mobooking-card-content p {
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.75rem; /* Increased spacing slightly */
     line-height: 1.6;
+}
+.mobooking-card-content p:last-child {
+    margin-bottom: 0;
 }
 .mobooking-card-content p strong {
     font-weight: 500;
-    color: #333;
+    color: #334155; /* Darker text for strong elements */
 }
-
-.mobooking-card-actions {
-    margin-top: 1.5rem;
-    padding-top: 1rem;
+.mobooking-card-content hr {
+    border: none;
     border-top: 1px solid #e2e8f0;
-    display: flex;
-    gap: 0.5rem; /* Space between buttons */
+    margin: 1rem 0;
 }
-.mobooking-card-actions .button {
-    margin-left: 0 !important; /* Override WP default button margin if any */
+.mobooking-card-content ul {
+    padding-left: 20px;
+    margin-top: 0.5rem;
 }
-
+.mobooking-card-content li {
+    margin-bottom: 0.5rem;
+}
 
 /*
 ==========================================================================
-Page Header
+Page Header (Common for List and Single View)
 ==========================================================================
 */
 .mobooking-page-header {
@@ -79,14 +79,14 @@ Page Header
     border-bottom: 1px solid #e2e8f0;
 }
 .mobooking-page-header h1 {
-    font-size: 1.75rem; /* Larger page titles */
+    font-size: 1.75rem;
     font-weight: 600;
     margin: 0;
 }
 
 /*
 ==========================================================================
-KPI Grid
+KPI Grid (Only on Bookings List Page)
 ==========================================================================
 */
 .mobooking-kpi-grid {
@@ -100,47 +100,43 @@ KPI Grid
     background-color: #ffffff;
     border: 1px solid #e2e8f0;
     border-radius: 0.5rem;
-    padding: 1.25rem; /* 20px */
+    padding: 1.25rem;
     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.03), 0 1px 2px 0 rgba(0, 0, 0, 0.02);
 }
 
 .mobooking-kpi-card h4 {
     margin-top: 0;
     margin-bottom: 0.5rem;
-    font-size: 0.875rem; /* 14px */
+    font-size: 0.875rem;
     font-weight: 500;
-    color: #4a5568; /* Gray-600 */
+    color: #4a5568;
 }
 
 .mobooking-kpi-card p {
     margin: 0;
-    font-size: 1.875rem; /* 30px */
+    font-size: 1.875rem;
     font-weight: 600;
-    color: #1a202c; /* Gray-900 */
+    color: #1a202c;
 }
 
 /*
 ==========================================================================
-Filters Bar
+Filters Bar (Only on Bookings List Page, uses .mobooking-card)
 ==========================================================================
 */
-.mobooking-filters-bar { /* This is a .mobooking-card now */
-    /* padding already handled by .mobooking-card */
-}
-
 .mobooking-filters-form {
     display: flex;
     flex-wrap: wrap;
-    gap: 1rem; /* Spacing between filter items/actions */
-    align-items: flex-end; /* Align items to bottom for better look with varied heights */
+    gap: 1rem;
+    align-items: flex-end;
 }
 
 .mobooking-filter-item {
     display: flex;
-    flex-direction: column; /* Stack label and input */
-    gap: 0.25rem; /* Space between label and input */
-    flex-grow: 1; /* Allow items to grow */
-    min-width: 150px; /* Minimum width before wrapping */
+    flex-direction: column;
+    gap: 0.25rem;
+    flex-grow: 1;
+    min-width: 150px;
 }
 .mobooking-filter-item label {
     font-size: 0.875rem;
@@ -149,70 +145,91 @@ Filters Bar
 }
 .mobooking-filter-item select,
 .mobooking-filter-item input[type="text"],
-.mobooking-filter-item input[type="date"] { /* Assuming datepicker might become input type date */
+.mobooking-filter-item input[type="date"] {
     padding: 0.5rem 0.75rem;
-    border: 1px solid #cbd5e0; /* Gray-300 */
-    border-radius: 0.375rem; /* Smaller radius for inputs */
+    border: 1px solid #cbd5e0;
+    border-radius: 0.375rem;
     font-size: 0.875rem;
-    width: 100%; /* Make inputs take full width of their flex item */
+    width: 100%;
     box-sizing: border-box;
-}
-.mobooking-filter-item input[type="text"].mobooking-datepicker {
-    /* Specific styles for datepicker if needed, otherwise inherits text input */
 }
 
 .mobooking-filter-actions {
     display: flex;
     gap: 0.5rem;
-    padding-top: 1.1em; /* Align with inputs if labels are above */
+    padding-top: 1.1em; /* Aligns with inputs if labels are on top */
 }
-
 
 /*
 ==========================================================================
-Bookings List / Grid
+Bookings Table (Only on Bookings List Page)
 ==========================================================================
 */
-.mobooking-bookings-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); /* Responsive cards */
-    gap: 1.5rem;
+.mobooking-table-responsive-wrapper {
+    overflow-x: auto;
+    background-color: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 3px 0 rgba(0,0,0,0.03),0 1px 2px 0 rgba(0,0,0,0.02);
+    margin-bottom: 1.5rem;
 }
-
-.mobooking-booking-item.mobooking-card {
-    /* General card styles already defined */
-    display: flex;
-    flex-direction: column; /* Stack header, content, actions */
+table.mobooking-table {
+    width: 100%;
+    border-collapse: collapse; /* Cleaner look */
 }
-.mobooking-booking-item .mobooking-card-content {
-    flex-grow: 1; /* Allow content to take available space */
+.mobooking-table th,
+.mobooking-table td {
+    text-align: left;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid #e2e8f0; /* Separator for rows */
 }
-
-.mobooking-created-date {
+.mobooking-table th {
+    background-color: #f8fafc;
+    font-weight: 600;
+    color: #334155;
+    font-size: 0.875rem;
+}
+.mobooking-table tbody tr:last-child td {
+    border-bottom: none; /* No border for last row */
+}
+.mobooking-table td {
+    vertical-align: middle;
+    font-size: 0.875rem;
+}
+.mobooking-table td small {
+    font-size: 0.9em; /* Relative to td font-size */
+    color: #64748b;
+}
+.mobooking-table-actions .button {
+    margin-right: 0.25rem;
+    padding: 0.25rem 0.5rem; /* Smaller buttons for table actions */
     font-size: 0.8rem;
-    color: #718096; /* Gray-500 */
+}
+.mobooking-table-actions .button:last-child {
+    margin-right: 0;
 }
 
 /* Status Badges */
 .mobooking-status-badge {
     padding: 0.25em 0.6em;
-    font-size: 0.75rem; /* 12px */
+    font-size: 0.75rem;
     font-weight: 500;
-    border-radius: 0.25rem; /* Pill like */
+    border-radius: 0.25rem;
     text-transform: capitalize;
     line-height: 1;
+    white-space: nowrap;
+    display: inline-block; /* Ensure it behaves well */
 }
-.mobooking-status-pending { background-color: #feebc8; color: #9c4221; } /* Orange-200, Orange-700 */
-.mobooking-status-confirmed { background-color: #c6f6d5; color: #2f855a; } /* Green-200, Green-700 */
-.mobooking-status-completed { background-color: #bee3f8; color: #2c5282; } /* Blue-200, Blue-700 */
-.mobooking-status-cancelled { background-color: #fed7d7; color: #c53030; } /* Red-200, Red-700 */
-.mobooking-status-on-hold { background-color: #faf089; color: #b7791f; } /* Yellow-200, Yellow-700 */
-.mobooking-status-processing { background-color: #e9d8fd; color: #6b46c1; } /* Purple-200, Purple-700 */
-
+.mobooking-status-pending { background-color: #feebc8; color: #9c4221; }
+.mobooking-status-confirmed { background-color: #c6f6d5; color: #2f855a; }
+.mobooking-status-completed { background-color: #bee3f8; color: #2c5282; }
+.mobooking-status-cancelled { background-color: #fed7d7; color: #c53030; }
+.mobooking-status-on-hold { background-color: #faf089; color: #b7791f; }
+.mobooking-status-processing { background-color: #e9d8fd; color: #6b46c1; }
 
 /*
 ==========================================================================
-Pagination
+Pagination (Only on Bookings List Page)
 ==========================================================================
 */
 .mobooking-pagination {
@@ -225,16 +242,16 @@ Pagination
     margin: 0 0.25rem;
     border: 1px solid #e2e8f0;
     border-radius: 0.375rem;
-    color: #2d3748; /* Gray-700 */
+    color: #2d3748;
     text-decoration: none;
     transition: background-color 0.2s, color 0.2s;
 }
 .mobooking-pagination .page-numbers:hover {
-    background-color: #edf2f7; /* Gray-100 */
-    border-color: #cbd5e0; /* Gray-300 */
+    background-color: #edf2f7;
+    border-color: #cbd5e0;
 }
 .mobooking-pagination .page-numbers.current {
-    background-color: var(--wp-admin-theme-color, #2271b1); /* Primary blue or WP admin theme color */
+    background-color: var(--wp-admin-theme-color, #2271b1);
     color: #ffffff;
     border-color: var(--wp-admin-theme-color, #2271b1);
     font-weight: 600;
@@ -242,144 +259,113 @@ Pagination
 
 /*
 ==========================================================================
-Modal Styling (replaces inline styles)
+Single Booking Details Page Specific Styles
 ==========================================================================
 */
-.mobooking-modal {
-    display: none; /* Hidden by default */
-    position: fixed;
-    z-index: 1050; /* High z-index */
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto; /* Enable scroll if needed */
-    background-color: rgba(0, 0, 0, 0.6); /* Darker overlay */
-}
-
-.mobooking-modal-content {
-    background-color: #ffffff;
-    margin: 5% auto; /* Centered, more top margin */
-    padding: 2rem; /* More padding */
-    border: none; /* Remove border, rely on shadow */
-    width: 90%;
-    max-width: 700px; /* Max width */
-    border-radius: 0.5rem; /* Consistent with cards */
-    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05); /* ShadCN Dialog shadow */
-    position: relative;
-    display: flex;
-    flex-direction: column;
-}
-
-.mobooking-modal-close {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    color: #a0aec0; /* Gray-500 */
-    font-size: 1.5rem; /* Larger close icon */
-    font-weight: normal; /* Not bold */
-    line-height: 1;
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0.25rem;
-}
-.mobooking-modal-close:hover {
-    color: #1a202c; /* Gray-900 */
-}
-
-.mobooking-modal .modal-section {
+.mobooking-details-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); /* Two columns that stack */
+    gap: 1.5rem;
     margin-bottom: 1.5rem;
-    padding-bottom: 1.5rem;
-    border-bottom: 1px solid #e2e8f0; /* Softer separator */
 }
-.mobooking-modal .modal-section:last-child {
-    border-bottom: none;
-    margin-bottom: 0;
-    padding-bottom: 0;
+.mobooking-details-column .mobooking-card:last-child {
+    margin-bottom: 0; /* No margin for last card in a column if grid gap handles it */
 }
-
-.mobooking-modal h2 { /* Modal Title */
-    margin-top: 0;
-    margin-bottom: 1.5rem;
-    font-size: 1.25rem; /* 20px */
-    font-weight: 600;
-    color: #1a202c;
+.mobooking-status-update-section {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid #e2e8f0;
 }
-.mobooking-modal h4 { /* Section Titles */
-    font-size: 1rem; /* 16px */
-    font-weight: 600;
-    color: #2d3748;
-    margin-top: 0;
-    margin-bottom: 0.75rem;
-}
-
-#modal-services-items-list ul {
-    padding-left: 1rem; /* Less indent */
-    margin-top: 0.5rem;
-    list-style: none;
-}
-#modal-services-items-list li {
+.mobooking-status-update-section p strong {
+    display: block;
     margin-bottom: 0.5rem;
+}
+.mobooking-status-form {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap; /* Allow wrapping for smaller screens */
+}
+.mobooking-status-form label {
     font-size: 0.875rem;
+    font-weight: 500;
+    color: #4a5568;
+    margin-right: 0.25rem;
 }
-#modal-services-items-list .option-list {
-    padding-left: 1rem;
-    font-size: 0.8rem;
-    color: #718096;
-}
-
-#modal-booking-status-select {
+#mobooking-single-booking-status-select {
     padding: 0.5rem 0.75rem;
     border: 1px solid #cbd5e0;
     border-radius: 0.375rem;
     font-size: 0.875rem;
-    margin-right: 0.5rem;
     min-width: 180px;
+    flex-grow: 1; /* Allow select to grow */
 }
-#modal-status-feedback {
+#mobooking-single-save-status-btn {
+    /* Uses default .button and .button-primary styles from WP */
+}
+.mobooking-status-feedback {
     font-style: italic;
     font-size: 0.875rem;
+    color: #4a5568;
+    margin-top: 0.5rem;
+    flex-basis: 100%; /* Take full width if it wraps */
+}
+.mobooking-status-feedback.success { color: #2f855a; }
+.mobooking-status-feedback.error { color: #c53030; }
+
+.mobooking-service-items-list {
+    list-style: none;
+    padding-left: 0;
+}
+.mobooking-service-items-list > li {
+    padding: 0.75rem 0;
+    border-bottom: 1px solid #e9ecef; /* Lighter separator for items */
+}
+.mobooking-service-items-list > li:last-child {
+    border-bottom: none;
+}
+.mobooking-service-options-list {
+    list-style: disc;
+    padding-left: 20px;
+    margin-top: 0.5rem;
+    font-size: 0.9em;
     color: #4a5568;
 }
 
 /* Responsive adjustments */
-@media (max-width: 782px) { /* WordPress admin breakpoint */
+@media (max-width: 782px) {
     .mobooking-kpi-grid {
         grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
         gap: 1rem;
     }
     .mobooking-kpi-card p {
-        font-size: 1.5rem; /* Smaller KPI values on mobile */
+        font-size: 1.5rem;
     }
 
     .mobooking-filters-form {
         flex-direction: column;
-        align-items: stretch; /* Make filter items take full width */
+        align-items: stretch;
     }
     .mobooking-filter-item {
-        min-width: 100%; /* Full width on mobile */
+        min-width: 100%;
     }
     .mobooking-filter-actions {
         padding-top: 0.5rem;
         justify-content: flex-start;
     }
 
-    .mobooking-bookings-grid {
-        grid-template-columns: 1fr; /* Single column for booking cards */
-        gap: 1rem;
+    .mobooking-table th, .mobooking-table td {
+        padding: 0.5rem;
+        font-size: 0.8rem; /* Even smaller font for table on mobile */
     }
-    .mobooking-card {
-        padding: 1rem;
+    .mobooking-table td small {
+        font-size: 0.85em; /* Relative to parent td */
     }
-    .mobooking-card-header h3 {
-        font-size: 1rem;
+    .mobooking-table-actions .button {
+        font-size: 0.75rem;
     }
-
-    .mobooking-modal-content {
-        margin: 5% auto;
-        width: 95%;
-        padding: 1.5rem;
+    .mobooking-details-grid {
+        grid-template-columns: 1fr; /* Single column for details cards on mobile */
     }
 }
 
@@ -401,41 +387,37 @@ Modal Styling (replaces inline styles)
     .mobooking-kpi-card p {
         font-size: 1.3rem;
     }
+    .mobooking-status-form {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    #mobooking-single-booking-status-select {
+        width: 100%;
+    }
+    #mobooking-single-save-status-btn {
+        width: 100%;
+    }
 }
 
-/* WordPress Button Overrides (if necessary, for consistency) */
-.mobooking-bookings-page-wrapper .button {
-    /* Example: Standardize button padding/height if WP defaults are inconsistent */
-    /* padding: 0.5rem 1rem; */
-    /* line-height: 1.5; */
-    /* border-radius: 0.375rem; */
+/* WordPress Button Overrides & Destructive Action Styles */
+.mobooking-bookings-page-wrapper .button,
+.mobooking-single-booking-page-wrapper .button {
+    border-radius: 0.375rem;
 }
-.mobooking-bookings-page-wrapper .button-primary {
-    /* background-color: var(--wp-admin-theme-color, #2271b1); */
-    /* border-color: var(--wp-admin-theme-color, #2271b1); */
-    /* color: #fff; */
-}
-/* Add more specific overrides if default WP admin button styles clash too much */
 
-/* Ensure delete button has a distinct, ShadCN-like destructive style */
-.mobooking-card-actions .mobooking-delete-booking-btn {
-    background-color: #fed7d7; /* Red-200 */
+.mobooking-table-actions .mobooking-delete-booking-btn {
+    background-color: #fed7d7;
     border-color: #fed7d7;
-    color: #c53030; /* Red-700 */
+    color: #c53030;
     font-weight: 500;
 }
-.mobooking-card-actions .mobooking-delete-booking-btn:hover {
-    background-color: #fbb6b6; /* Red-300 */
+.mobooking-table-actions .mobooking-delete-booking-btn:hover,
+.mobooking-table-actions .mobooking-delete-booking-btn:focus {
+    background-color: #fbb6b6;
     border-color: #fbb6b6;
-    color: #9b2c2c; /* Red-800 */
+    color: #9b2c2c;
 }
 
-/* Ensure primary action buttons in modal are styled consistently */
-#modal-save-status-btn.button-primary {
-   /* Already inherits general button styles, WP might handle this well */
-}
-
-/* Helper class if needed for visually hidden labels (for accessibility) */
 .mobooking-visually-hidden {
     position: absolute;
     width: 1px;

--- a/assets/js/dashboard-bookings.js
+++ b/assets/js/dashboard-bookings.js
@@ -57,13 +57,35 @@ jQuery(document).ready(function($) {
                         // Format data for display
                         bookingDataForTemplate.total_price_formatted = currencyCode + ' ' + parseFloat(booking.total_price).toFixed(2);
                         bookingDataForTemplate.status_display = mobooking_bookings_params.statuses[booking.status] || booking.status;
-                        // Basic date formatting, consider moment.js or similar for complex needs
-                        try {
-                            const dateObj = new Date(booking.created_at);
-                            bookingDataForTemplate.created_at_formatted = dateObj.toLocaleDateString() + ' ' + dateObj.toLocaleTimeString();
-                        } catch(e) { bookingDataForTemplate.created_at_formatted = booking.created_at; }
 
-                        bookingsListContainer.append(renderTemplate(bookingItemTemplate, bookingDataForTemplate));
+                        // Date and Time formatting for booking_date and booking_time
+                        // These should match the format used in the initial PHP render if possible
+                        // For simplicity, using toLocaleDateString and toLocaleTimeString
+                        // A more robust solution might involve a date formatting library or server-side formatted strings
+                        try {
+                            const bookingDate = new Date(booking.booking_date + 'T' + booking.booking_time); // Combine date and time for proper Date object
+                            bookingDataForTemplate.booking_date_formatted = bookingDate.toLocaleDateString();
+                            bookingDataForTemplate.booking_time_formatted = bookingDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+                        } catch(e) {
+                            bookingDataForTemplate.booking_date_formatted = booking.booking_date;
+                            bookingDataForTemplate.booking_time_formatted = booking.booking_time;
+                        }
+
+                        // Construct details_page_url
+                        // Assuming mobooking_bookings_params.bookings_page_base_url is like 'admin.php?page=mobooking'
+                        // This might need to be passed from PHP if not already available.
+                        // For now, constructing it based on a common pattern.
+                        // A better approach is to have a bookings_page_url in mobooking_bookings_params.
+                        let baseUrl = mobooking_bookings_params.bookings_page_url || 'admin.php?page=mobooking';
+                        bookingDataForTemplate.details_page_url = baseUrl + '&action=view_booking&booking_id=' + booking.booking_id;
+
+
+                        // The renderTemplate function expects all keys in the template to be present in bookingDataForTemplate
+                        // Ensure all fields used in the template (`booking_reference`, `customer_name`, `customer_email`, `status`)
+                        // are directly available on `booking` or added to `bookingDataForTemplate`.
+                        // `created_at_formatted` is no longer in the table template.
+
+                        bookingsListContainer.find('tbody').append(renderTemplate(bookingItemTemplate, bookingDataForTemplate));
                     });
                     renderPagination(response.data.total_count, response.data.per_page, response.data.current_page);
                 } else if (response.success) {
@@ -130,321 +152,41 @@ jQuery(document).ready(function($) {
          $('.mobooking-datepicker').attr('type', 'date'); // Fallback to native
     }
 
-
-    // Modal elements
-    const detailsModal = $('#mobooking-booking-details-modal');
-    const modalCloseBtn = detailsModal.find('.mobooking-modal-close');
-    const modalBookingRef = $('#modal-booking-ref');
-    const modalStatusSelect = $('#modal-booking-status-select');
-    const modalSaveStatusBtn = $('#modal-save-status-btn');
-    const modalStatusFeedback = $('#modal-status-feedback');
-    const modalCustomerName = $('#modal-customer-name');
-    const modalCustomerEmail = $('#modal-customer-email');
-    const modalCustomerPhone = $('#modal-customer-phone');
-    const modalServiceAddress = $('#modal-service-address');
-    const modalBookingDate = $('#modal-booking-date');
-    const modalBookingTime = $('#modal-booking-time');
-    const modalSpecialInstructions = $('#modal-special-instructions');
-    const modalServicesItemsList = $('#modal-services-items-list');
-    const modalDiscountAmount = $('#modal-discount-amount');
-    const modalFinalTotal = $('#modal-final-total');
-    const modalCurrentBookingIdField = $('#modal-current-booking-id');
-
-    // Modal Handling
-    modalCloseBtn.on('click', function() {
-        detailsModal.fadeOut();
-    });
-
-    $(window).on('click', function(event) {
-        if ($(event.target).is(detailsModal)) {
-            detailsModal.fadeOut();
-        }
-    });
-
-    function formatServiceItemsForModal(items) {
-        if (!items || items.length === 0) {
-            return '<p>' + (mobooking_bookings_params.i18n.no_items_in_booking || 'No items in this booking.') + '</p>';
-        }
-        let html = '<ul>';
-        items.forEach(function(item) {
-            html += `<li><strong>${sanitizeHTML(item.service_name)}</strong> (Qty: ${item.quantity || 1}) - Price: ${currencyCode} ${parseFloat(item.item_total_price).toFixed(2)}`;
-            if (item.selected_options && item.selected_options.length > 0) {
-                html += '<ul class="option-list">';
-                item.selected_options.forEach(function(opt) {
-                    let impact_val = parseFloat(opt.price_impact);
-                    let impact_display = '';
-                    if (impact_val !== 0) {
-                        let sign = impact_val > 0 ? '+' : '';
-                        // For option impacts, it's usually just AMOUNT CURRENCY_CODE, e.g. +5.00 USD or -2.50 EUR
-                        impact_display = ` (${sign}${impact_val.toFixed(2)} ${currencyCode})`;
-                    }
-                    html += `<li><em>${sanitizeHTML(opt.name)}:</em> ${sanitizeHTML(opt.value)}${impact_display}</li>`;
-                });
-                html += '</ul>';
-            }
-            html += '</li>';
-        });
-        html += '</ul>';
-        return html;
-    }
-
-
-    // View Details button
-    bookingsListContainer.on('click', '.mobooking-view-booking-details-btn', function() {
-        const bookingId = $(this).data('booking-id');
-        modalCurrentBookingIdField.val(bookingId); // Store for status update
-        modalStatusFeedback.empty().removeClass('success error');
-        modalServicesItemsList.html('<p>' + (mobooking_bookings_params.i18n.loading_details || 'Loading details...') + '</p>');
-        detailsModal.fadeIn();
-
-        $.ajax({
-            url: mobooking_bookings_params.ajax_url,
-            type: 'POST',
-            data: {
-                action: 'mobooking_get_tenant_booking_details',
-                nonce: mobooking_bookings_params.nonce,
-                booking_id: bookingId
-            },
-            success: function(response) {
-                if (response.success && response.data) {
-                    const booking = response.data;
-                    modalBookingRef.text(booking.booking_reference);
-                    modalCustomerName.text(booking.customer_name);
-                    modalCustomerEmail.text(booking.customer_email);
-                    modalCustomerPhone.text(booking.customer_phone);
-                    modalServiceAddress.html(sanitizeHTML(booking.service_address).replace(/\n/g, '<br>'));
-                    modalBookingDate.text(booking.booking_date);
-                    modalBookingTime.text(booking.booking_time);
-                    modalSpecialInstructions.html(booking.special_instructions ? sanitizeHTML(booking.special_instructions).replace(/\n/g, '<br>') : (mobooking_bookings_params.i18n.none || 'None'));
-
-                    modalServicesItemsList.html(formatServiceItemsForModal(booking.items));
-
-                    modalDiscountAmount.text(currencyCode + ' ' + parseFloat(booking.discount_amount || 0).toFixed(2));
-                    modalFinalTotal.text(currencyCode + ' ' + parseFloat(booking.total_price).toFixed(2));
-
-                    // Populate status dropdown
-                    modalStatusSelect.empty();
-                    const statuses = mobooking_bookings_params.statuses || {};
-                    for (const key in statuses) {
-                        if (key === "") continue; // Skip "All Statuses" option
-                        modalStatusSelect.append($('<option>', { value: key, text: statuses[key] }));
-                    }
-                    modalStatusSelect.val(booking.status);
-
-                } else {
-                    modalServicesItemsList.html('<p>' + (response.data.message || mobooking_bookings_params.i18n.error_loading_details || 'Error loading details.') + '</p>');
-                }
-            },
-            error: function() {
-                 modalServicesItemsList.html('<p>' + (mobooking_bookings_params.i18n.error_loading_details || 'Error loading details.') + '</p>');
-            }
-        });
-    });
-
-    // Save Status button in Modal
-    modalSaveStatusBtn.on('click', function() {
-        const bookingId = modalCurrentBookingIdField.val();
-        const newStatus = modalStatusSelect.val();
-        if (!bookingId || !newStatus) {
-            modalStatusFeedback.text(mobooking_bookings_params.i18n.error_status_update || 'Invalid data for status update.').addClass('error').show();
-            return;
-        }
-
-        modalStatusFeedback.text(mobooking_bookings_params.i18n.updating_status || 'Updating...').removeClass('success error').show();
-        $(this).prop('disabled', true);
-
-        $.ajax({
-            url: mobooking_bookings_params.ajax_url,
-            type: 'POST',
-            data: {
-                action: 'mobooking_update_booking_status',
-                nonce: mobooking_bookings_params.nonce,
-                booking_id: bookingId,
-                new_status: newStatus
-            },
-            success: function(response) {
-                if (response.success) {
-                    modalStatusFeedback.text(response.data.message).addClass('success').removeClass('error').show();
-                    loadBookings(currentFilters.paged); // Refresh the main list
-                } else {
-                    modalStatusFeedback.text(response.data.message || mobooking_bookings_params.i18n.error_status_update).addClass('error').removeClass('success').show();
-                }
-            },
-            error: function() {
-                 modalStatusFeedback.text(mobooking_bookings_params.i18n.error_status_update_ajax || 'AJAX error updating status.').addClass('error').removeClass('success').show();
-            },
-            complete: function() {
-                modalSaveStatusBtn.prop('disabled', false);
-                setTimeout(function() { modalStatusFeedback.fadeOut(); }, 3000);
-            }
-        });
-    });
-
+    // --- Modal related code removed ---
+    // const detailsModal = ... (and all related modal variables and functions)
+    // modalCloseBtn.on('click', ...)
+    // $(window).on('click', ...) for modal
+    // formatServiceItemsForModal(...)
+    // bookingsListContainer.on('click', '.mobooking-view-booking-details-btn', ...) - this is now a link
+    // modalSaveStatusBtn.on('click', ...)
+    // Edit fields functionality (modalEditButton, toggleEditMode, etc.)
+    // populateModalWithBookingData(...)
+    // viewBookingDetails(...) function
 
     // Initial load is now handled by PHP.
-    // loadBookings(); // Removed
+    // loadBookings(); // Removed, as initial content is server-rendered. Filters will trigger AJAX.
 
     // --- CRUD Operations ---
 
     // CREATE BOOKING (Placeholder - Needs UI: Add Booking Button & Modal)
-    // This requires a new modal and form similar to the public booking form.
-    // For now, this is a placeholder. A button with id="mobooking-add-booking-btn" would trigger this.
+    // This functionality is not part of the current refactor to table view / single page details.
+    // If it were to be re-implemented, it would likely involve a separate page or a new modal.
     $('#mobooking-add-booking-btn').on('click', function() {
-        alert('Add New Booking functionality to be implemented. This will require a new form/modal.');
-        // 1. Show a modal with form fields for:
-        //    - Customer Details (name, email, phone, address)
-        //    - Service Selection (complex: needs service list, options, pricing logic)
-        //    - Booking Date/Time
-        //    - Special Instructions
-        // 2. On submit, gather data into a payload matching `create_booking` in PHP.
-        //    const bookingData = {
-        //        customer_details: { customer_name: '...', ... },
-        //        selected_services: [ { service_id: ..., configured_options: [...] } ],
-        //        pricing: { subtotal: ..., discount: ..., final_total: ... }, // Server will recalculate
-        //        // ... any other fields required by create_booking
-        //    };
-        // 3. AJAX call:
-        //    $.ajax({
-        //        url: mobooking_bookings_params.ajax_url,
-        //        type: 'POST',
-        //        data: {
-        //            action: 'mobooking_create_dashboard_booking',
-        //            nonce: mobooking_bookings_params.nonce,
-        //            booking_data: JSON.stringify(bookingData)
-        //        },
-        //        success: function(response) { if (response.success) loadBookings(1); /* or prepend */ },
-        //        error: function() { /* handle error */ }
-        //    });
+        // For now, this button might link to a future "Add New Booking" page,
+        // or trigger a new modal designed for creation if that's preferred.
+        // The existing alert is a placeholder.
+        alert('Add New Booking functionality to be implemented. This will require a new form/modal or a separate page.');
     });
 
-
-    // UPDATE BOOKING FIELDS (in existing modal)
-    let isEditMode = false;
-    const modalEditButton = $('<button class="button" id="modal-edit-fields-btn" style="margin-left: 10px;">' + (mobooking_bookings_params.i18n.edit_fields || 'Edit Fields') + '</button>');
-    const modalSaveChangesButton = $('<button class="button button-primary" id="modal-save-fields-btn" style="margin-left: 10px; display:none;">' + (mobooking_bookings_params.i18n.save_changes || 'Save Changes') + '</button>');
-    const modalCancelEditButton = $('<button class="button" id="modal-cancel-edit-btn" style="margin-left: 5px; display:none;">' + (mobooking_bookings_params.i18n.cancel || 'Cancel') + '</button>');
-
-    // Insert new buttons after the status save button or in a specific place
-    modalSaveStatusBtn.after(modalCancelEditButton).after(modalSaveChangesButton).after(modalEditButton);
-
-    function toggleEditMode(enable) {
-        isEditMode = enable;
-        modalEditButton.toggle(!enable);
-        modalSaveChangesButton.toggle(enable);
-        modalCancelEditButton.toggle(enable);
-        modalSaveStatusBtn.toggle(!enable); // Hide status save when editing other fields
-        modalStatusSelect.prop('disabled', enable); // Disable status select in field edit mode
-
-        // Fields that can be edited (add more as needed)
-        const fields = {
-            'modal-customer-name': modalCustomerName.text(),
-            'modal-customer-email': modalCustomerEmail.text(),
-            'modal-customer-phone': modalCustomerPhone.text(),
-            'modal-service-address': modalServiceAddress.html().replace(/<br\s*\/?>/gi, '\n'), // Convert <br> to newline for textarea
-            'modal-booking-date': modalBookingDate.text(), // Consider datepicker
-            'modal-booking-time': modalBookingTime.text(), // Consider timepicker
-            'modal-special-instructions': modalSpecialInstructions.html().replace(/<br\s*\/?>/gi, '\n'),
-        };
-
-        for (const id in fields) {
-            const element = $('#' + id);
-            if (enable) {
-                let inputType = 'text';
-                if (id === 'modal-service-address' || id === 'modal-special-instructions') {
-                    inputType = 'textarea';
-                }
-                const currentVal = fields[id];
-                let inputHtml = inputType === 'textarea' ?
-                    `<textarea id="${id}-input" class="widefat" style="min-height:60px;">${sanitizeHTML(currentVal)}</textarea>` :
-                    `<input type="${inputType}" id="${id}-input" value="${sanitizeHTML(currentVal)}" class="widefat" />`;
-
-                if (id === 'modal-booking-date' && typeof $.fn.datepicker === 'function') {
-                     element.html(inputHtml);
-                     $(`#${id}-input`).datepicker({ dateFormat: 'yy-mm-dd' });
-                } else if (id === 'modal-booking-date') {
-                     element.html(inputHtml); // native date picker might be `type="date"`
-                     $(`#${id}-input`).prop('type', 'date');
-                }
-                else {
-                    element.html(inputHtml);
-                }
-            } else {
-                // Restore original text (or updated text if save was successful)
-                // This part will be enhanced by saving the original values or re-fetching
-                element.html(fields[id].replace(/\n/g, '<br>')); // Display <br> again
-            }
-        }
-    }
-
-    modalEditButton.on('click', function() {
-        toggleEditMode(true);
-    });
-
-    modalCancelEditButton.on('click', function() {
-        toggleEditMode(false);
-        // TODO: Restore original values if no save occurred. Need to store them when edit mode starts.
-        // For now, it just toggles back, potentially losing user input if they didn't save.
-        // A proper implementation would re-populate with data fetched when modal opened or last saved.
-        // This can be done by re-triggering the AJAX call or storing initial modal data.
-        // For simplicity here, we'll just revert to text, which might not be original if user typed then cancelled.
-        // The best is to re-fetch or use stored original data.
-         const bookingId = modalCurrentBookingIdField.val();
-         // Re-fetch to reset fields (simplest way to handle "cancel" without complex state management)
-         if(bookingId) viewBookingDetails(bookingId, false); // false to not re-enable edit mode
-    });
-
-    modalSaveChangesButton.on('click', function() {
-        const bookingId = modalCurrentBookingIdField.val();
-        if (!bookingId) return;
-
-        const fieldsToUpdate = {
-            customer_name: $('#modal-customer-name-input').val(),
-            customer_email: $('#modal-customer-email-input').val(),
-            customer_phone: $('#modal-customer-phone-input').val(),
-            service_address: $('#modal-service-address-input').val(),
-            booking_date: $('#modal-booking-date-input').val(),
-            booking_time: $('#modal-booking-time-input').val(),
-            special_instructions: $('#modal-special-instructions-input').val(),
-        };
-
-        modalStatusFeedback.text(mobooking_bookings_params.i18n.saving_changes || 'Saving...').removeClass('success error').show();
-        $(this).prop('disabled', true);
-
-        $.ajax({
-            url: mobooking_bookings_params.ajax_url,
-            type: 'POST',
-            data: {
-                action: 'mobooking_update_dashboard_booking_fields',
-                nonce: mobooking_bookings_params.nonce,
-                booking_id: bookingId,
-                fields_to_update: JSON.stringify(fieldsToUpdate)
-            },
-            success: function(response) {
-                if (response.success && response.data.booking_data) {
-                    modalStatusFeedback.text(response.data.message).addClass('success').show();
-                    toggleEditMode(false);
-                    // Update displayed fields in modal with response.data.booking_data
-                    populateModalWithBookingData(response.data.booking_data);
-                    loadBookings(currentFilters.paged); // Refresh the main list to reflect changes
-                } else {
-                    modalStatusFeedback.text(response.data.message || 'Error saving changes.').addClass('error').show();
-                }
-            },
-            error: function() {
-                modalStatusFeedback.text('AJAX error saving changes.').addClass('error').show();
-            },
-            complete: function() {
-                modalSaveChangesButton.prop('disabled', false);
-                setTimeout(function() { modalStatusFeedback.fadeOut(); }, 3000);
-            }
-        });
-    });
 
     // DELETE BOOKING
+    // Adjusted to work with table rows.
     bookingsListContainer.on('click', '.mobooking-delete-booking-btn', function(e) {
         e.preventDefault();
         const bookingId = $(this).data('booking-id');
-        const bookingRef = $(this).closest('.mobooking-booking-item').find('h3').text(); // Get ref for confirm message
+        const $row = $(this).closest('tr');
+        // Attempt to get booking reference from the first cell (td) in the row
+        const bookingRef = $row.find('td:first').text();
 
         if (confirm( (mobooking_bookings_params.i18n.confirm_delete || 'Are you sure you want to delete booking %s?').replace('%s', bookingRef) )) {
             $.ajax({
@@ -452,90 +194,31 @@ jQuery(document).ready(function($) {
                 type: 'POST',
                 data: {
                     action: 'mobooking_delete_dashboard_booking',
-                    nonce: mobooking_bookings_params.nonce,
+                    nonce: mobooking_bookings_params.nonce, // Ensure this nonce is still valid and appropriate
                     booking_id: bookingId
                 },
                 success: function(response) {
                     if (response.success) {
-                        alert(response.data.message); // Or use a less obtrusive notification
-                        loadBookings(currentFilters.paged); // Reload current page
+                        // On successful deletion, remove the row from the table or reload.
+                        // For simplicity, reloading the current view.
+                        loadBookings(currentFilters.paged);
+                        // Alternatively, to remove the row directly without full reload:
+                        // $row.fadeOut(300, function() { $(this).remove(); });
+                        // If removing directly, also update total counts if displayed.
+                        if(mobooking_bookings_params.i18n.booking_deleted_successfully) {
+                             alert(mobooking_bookings_params.i18n.booking_deleted_successfully);
+                        } else {
+                            alert(response.data.message || 'Booking deleted.');
+                        }
                     } else {
-                        alert('Error: ' + response.data.message);
+                        alert('Error: ' + (response.data.message || mobooking_bookings_params.i18n.error_deleting_booking || 'Could not delete booking.'));
                     }
                 },
                 error: function() {
-                    alert('AJAX error deleting booking.');
+                    alert(mobooking_bookings_params.i18n.error_deleting_booking_ajax || 'AJAX error deleting booking.');
                 }
             });
         }
-    });
-
-    // Helper to populate modal (used after initial load and after field update)
-    function populateModalWithBookingData(booking) {
-        modalBookingRef.text(booking.booking_reference);
-        modalCustomerName.text(booking.customer_name);
-        modalCustomerEmail.text(booking.customer_email);
-        modalCustomerPhone.text(booking.customer_phone || (mobooking_bookings_params.i18n.not_provided || 'N/A') );
-        modalServiceAddress.html(sanitizeHTML(booking.service_address || '').replace(/\n/g, '<br>'));
-        modalBookingDate.text(booking.booking_date); // Consider formatting
-        modalBookingTime.text(booking.booking_time);
-        modalSpecialInstructions.html(booking.special_instructions ? sanitizeHTML(booking.special_instructions).replace(/\n/g, '<br>') : (mobooking_bookings_params.i18n.none || 'None'));
-
-        modalServicesItemsList.html(formatServiceItemsForModal(booking.items));
-
-        modalDiscountAmount.text(currencyCode + ' ' + parseFloat(booking.discount_amount || 0).toFixed(2));
-        modalFinalTotal.text(currencyCode + ' ' + parseFloat(booking.total_price).toFixed(2));
-
-        modalStatusSelect.empty();
-        const statuses = mobooking_bookings_params.statuses || {};
-        for (const key in statuses) {
-            if (key === "") continue;
-            modalStatusSelect.append($('<option>', { value: key, text: statuses[key] }));
-        }
-        modalStatusSelect.val(booking.status);
-        modalCurrentBookingIdField.val(booking.booking_id);
-    }
-
-    // Modified View Details to use the helper and manage edit mode
-    function viewBookingDetails(bookingId, enterEditMode = false) {
-        modalCurrentBookingIdField.val(bookingId);
-        modalStatusFeedback.empty().removeClass('success error');
-        modalServicesItemsList.html('<p>' + (mobooking_bookings_params.i18n.loading_details || 'Loading details...') + '</p>');
-
-        // Ensure edit mode is reset if not explicitly requested
-        if (isEditMode && !enterEditMode) {
-            toggleEditMode(false);
-        }
-
-        detailsModal.fadeIn();
-
-        $.ajax({
-            url: mobooking_bookings_params.ajax_url,
-            type: 'POST',
-            data: {
-                action: 'mobooking_get_tenant_booking_details',
-                nonce: mobooking_bookings_params.nonce,
-                booking_id: bookingId
-            },
-            success: function(response) {
-                if (response.success && response.data) {
-                    populateModalWithBookingData(response.data);
-                    if (enterEditMode) {
-                        toggleEditMode(true);
-                    }
-                } else {
-                    modalServicesItemsList.html('<p>' + (response.data.message || mobooking_bookings_params.i18n.error_loading_details || 'Error loading details.') + '</p>');
-                }
-            },
-            error: function() {
-                 modalServicesItemsList.html('<p>' + (mobooking_bookings_params.i18n.error_loading_details || 'Error loading details.') + '</p>');
-            }
-        });
-    }
-
-    bookingsListContainer.on('click', '.mobooking-view-booking-details-btn', function() {
-        const bookingId = $(this).data('booking-id');
-        viewBookingDetails(bookingId);
     });
 
 });

--- a/dashboard/page-booking-single.php
+++ b/dashboard/page-booking-single.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Dashboard Page: Single Booking Details
+ * This file is included by page-bookings.php when action=view_booking is set.
+ * Expected variables: $single_booking_id, $bookings_manager, $currency_symbol, $current_user_id
+ * @package MoBooking
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+if ( ! isset( $single_booking_id ) || ! is_numeric( $single_booking_id ) ) {
+    echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid booking ID specified.', 'mobooking' ) . '</p></div>';
+    return;
+}
+
+$booking_id_to_fetch = $single_booking_id;
+$user_id_for_permission_check = $current_user_id; // The logged-in user
+
+// Determine the actual owner ID of the booking for fetching and broad permission.
+// The get_booking method in Bookings.php needs the owner's ID.
+$booking_owner_id_for_fetch = null;
+$booking_to_check_ownership = $bookings_manager->wpdb->get_row( // Direct DB check to find owner first
+    $bookings_manager->wpdb->prepare(
+        "SELECT user_id FROM " . MoBooking\Classes\Database::get_table_name('bookings') . " WHERE booking_id = %d",
+        $booking_id_to_fetch
+    )
+);
+
+if (!$booking_to_check_ownership) {
+    echo '<div class="notice notice-error"><p>' . esc_html__( 'Booking not found.', 'mobooking' ) . '</p></div>';
+    return;
+}
+$actual_booking_owner_id = (int) $booking_to_check_ownership->user_id;
+
+// Permission Check: Can the current user view this booking?
+$can_view = false;
+if ( MoBooking\Classes\Auth::is_user_business_owner( $user_id_for_permission_check ) ) {
+    if ( $user_id_for_permission_check === $actual_booking_owner_id ) {
+        $can_view = true;
+        $booking_owner_id_for_fetch = $user_id_for_permission_check;
+    }
+} elseif ( MoBooking\Classes\Auth::is_user_worker( $user_id_for_permission_check ) ) {
+    $worker_owner_id = MoBooking\Classes\Auth::get_business_owner_id_for_worker( $user_id_for_permission_check );
+    if ( $worker_owner_id && $worker_owner_id === $actual_booking_owner_id ) {
+        $can_view = true;
+        $booking_owner_id_for_fetch = $worker_owner_id;
+    }
+}
+
+if ( ! $can_view ) {
+    echo '<div class="notice notice-error"><p>' . esc_html__( 'You do not have permission to view this booking.', 'mobooking' ) . '</p></div>';
+    return;
+}
+
+// Fetch the full booking details using the determined owner ID
+$booking = $bookings_manager->get_booking( $booking_id_to_fetch, $booking_owner_id_for_fetch );
+
+if ( ! $booking ) {
+    // This case should ideally be caught by the previous check, but as a fallback.
+    echo '<div class="notice notice-error"><p>' . esc_html__( 'Booking details could not be retrieved or access denied.', 'mobooking' ) . '</p></div>';
+    return;
+}
+
+// Prepare data for display
+$status_display = !empty($booking['status']) ? ucfirst(str_replace('-', ' ', $booking['status'])) : __('N/A', 'mobooking');
+$total_price_formatted = esc_html($currency_symbol . number_format_i18n(floatval($booking['total_price']), 2));
+$discount_amount_formatted = esc_html($currency_symbol . number_format_i18n(floatval($booking['discount_amount']), 2));
+$booking_date_formatted = date_i18n(get_option('date_format'), strtotime($booking['booking_date']));
+$booking_time_formatted = date_i18n(get_option('time_format'), strtotime($booking['booking_time']));
+$created_at_formatted = date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($booking['created_at']));
+$updated_at_formatted = date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($booking['updated_at']));
+
+$booking_statuses_for_select = [ // To populate the select dropdown
+    'pending' => __('Pending', 'mobooking'),
+    'confirmed' => __('Confirmed', 'mobooking'),
+    'completed' => __('Completed', 'mobooking'),
+    'cancelled' => __('Cancelled', 'mobooking'),
+    'on-hold' => __('On Hold', 'mobooking'),
+    'processing' => __('Processing', 'mobooking'),
+];
+
+// Base URL for the main bookings page (for back button)
+$main_bookings_page_url = admin_url('admin.php?page=mobooking');
+
+?>
+<div class="mobooking-single-booking-page-wrapper">
+    <div class="mobooking-page-header">
+        <h1><?php printf(esc_html__('Booking Details: %s', 'mobooking'), esc_html($booking['booking_reference'])); ?></h1>
+        <a href="<?php echo esc_url($main_bookings_page_url); ?>" class="button"><?php esc_html_e('&laquo; Back to Bookings List', 'mobooking'); ?></a>
+    </div>
+
+    <div class="mobooking-details-grid">
+        <?php // Column 1: Core Details & Status ?>
+        <div class="mobooking-details-column">
+            <div class="mobooking-card">
+                <div class="mobooking-card-header">
+                    <h3><?php esc_html_e('Booking Overview', 'mobooking'); ?></h3>
+                </div>
+                <div class="mobooking-card-content">
+                    <p><strong><?php esc_html_e('Reference:', 'mobooking'); ?></strong> <?php echo esc_html($booking['booking_reference']); ?></p>
+                    <p><strong><?php esc_html_e('Booked Date:', 'mobooking'); ?></strong> <?php echo esc_html($booking_date_formatted); ?></p>
+                    <p><strong><?php esc_html_e('Booked Time:', 'mobooking'); ?></strong> <?php echo esc_html($booking_time_formatted); ?></p>
+                    <hr>
+                    <div class="mobooking-status-update-section">
+                        <p><strong><?php esc_html_e('Current Status:', 'mobooking'); ?></strong> <span id="mobooking-current-status-display" class="mobooking-status-badge mobooking-status-<?php echo esc_attr($booking['status']); ?>"><?php echo esc_html($status_display); ?></span></p>
+                        <div class="mobooking-status-form">
+                            <label for="mobooking-single-booking-status-select"><?php esc_html_e('Change Status:', 'mobooking'); ?></label>
+                            <select id="mobooking-single-booking-status-select" data-booking-id="<?php echo esc_attr($booking['booking_id']); ?>">
+                                <?php foreach ($booking_statuses_for_select as $value => $label) : ?>
+                                    <option value="<?php echo esc_attr($value); ?>" <?php selected($booking['status'], $value); ?>><?php echo esc_html($label); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                            <button id="mobooking-single-save-status-btn" class="button button-primary button-small"><?php esc_html_e('Save Status', 'mobooking'); ?></button>
+                        </div>
+                        <div id="mobooking-single-status-feedback" class="mobooking-status-feedback"></div>
+                    </div>
+                    <hr>
+                    <p><small><strong><?php esc_html_e('Created:', 'mobooking'); ?></strong> <?php echo esc_html($created_at_formatted); ?></small></p>
+                    <p><small><strong><?php esc_html_e('Last Updated:', 'mobooking'); ?></strong> <?php echo esc_html($updated_at_formatted); ?></small></p>
+                </div>
+            </div>
+
+            <div class="mobooking-card">
+                <div class="mobooking-card-header">
+                    <h3><?php esc_html_e('Pricing Information', 'mobooking'); ?></h3>
+                </div>
+                <div class="mobooking-card-content">
+                    <?php if (isset($booking['items']) && is_array($booking['items']) && !empty($booking['items'])): ?>
+                        <?php $subtotal = 0; foreach($booking['items'] as $item) { $subtotal += floatval($item['item_total_price']); } ?>
+                        <p><strong><?php esc_html_e('Subtotal:', 'mobooking'); ?></strong> <?php echo esc_html($currency_symbol . number_format_i18n($subtotal, 2)); ?></p>
+                    <?php endif; ?>
+                    <p><strong><?php esc_html_e('Discount Applied:', 'mobooking'); ?></strong> <?php echo esc_html($discount_amount_formatted); ?></p>
+                    <p><strong><?php esc_html_e('Final Total:', 'mobooking'); ?></strong> <strong style="font-size: 1.2em;"><?php echo $total_price_formatted; ?></strong></p>
+                    <p><strong><?php esc_html_e('Payment Status:', 'mobooking'); ?></strong> <?php echo esc_html(ucfirst($booking['payment_status'])); ?></p>
+                </div>
+            </div>
+        </div>
+
+        <?php // Column 2: Customer & Service Details ?>
+        <div class="mobooking-details-column">
+            <div class="mobooking-card">
+                <div class="mobooking-card-header">
+                    <h3><?php esc_html_e('Customer Information', 'mobooking'); ?></h3>
+                </div>
+                <div class="mobooking-card-content">
+                    <p><strong><?php esc_html_e('Name:', 'mobooking'); ?></strong> <?php echo esc_html($booking['customer_name']); ?></p>
+                    <p><strong><?php esc_html_e('Email:', 'mobooking'); ?></strong> <a href="mailto:<?php echo esc_attr($booking['customer_email']); ?>"><?php echo esc_html($booking['customer_email']); ?></a></p>
+                    <p><strong><?php esc_html_e('Phone:', 'mobooking'); ?></strong> <?php echo esc_html($booking['customer_phone'] ? $booking['customer_phone'] : 'N/A'); ?></p>
+                    <p><strong><?php esc_html_e('Service Address:', 'mobooking'); ?></strong><br><?php echo nl2br(esc_html($booking['service_address'])); ?></p>
+                    <?php if (!empty($booking['zip_code'])): ?>
+                        <p><strong><?php esc_html_e('Zip Code:', 'mobooking'); ?></strong> <?php echo esc_html($booking['zip_code']); ?></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <?php if (!empty($booking['special_instructions'])): ?>
+            <div class="mobooking-card">
+                <div class="mobooking-card-header">
+                    <h3><?php esc_html_e('Special Instructions', 'mobooking'); ?></h3>
+                </div>
+                <div class="mobooking-card-content">
+                    <p><?php echo nl2br(esc_html($booking['special_instructions'])); ?></p>
+                </div>
+            </div>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <?php // Services and Options Booked - Full Width Card ?>
+    <?php if (isset($booking['items']) && is_array($booking['items']) && !empty($booking['items'])): ?>
+    <div class="mobooking-card">
+        <div class="mobooking-card-header">
+            <h3><?php esc_html_e('Services & Options Booked', 'mobooking'); ?></h3>
+        </div>
+        <div class="mobooking-card-content">
+            <ul class="mobooking-service-items-list">
+                <?php foreach ($booking['items'] as $item): ?>
+                    <li>
+                        <strong><?php echo esc_html($item['service_name']); ?></strong>
+                        (<?php echo esc_html($currency_symbol . number_format_i18n(floatval($item['service_price']), 2)); ?>)
+                        <?php if (!empty($item['selected_options']) && is_array($item['selected_options'])): ?>
+                            <ul class="mobooking-service-options-list">
+                                <?php foreach ($item['selected_options'] as $option): ?>
+                                    <li>
+                                        <?php echo esc_html($option['name']); ?>: <?php echo esc_html($option['value']); ?>
+                                        (<?php echo ($option['price_impact'] >= 0 ? '+' : '') . esc_html($currency_symbol . number_format_i18n(floatval($option['price_impact']), 2)); ?>)
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                        <p style="text-align: right;"><em><?php esc_html_e('Item Total:', 'mobooking'); ?> <?php echo esc_html($currency_symbol . number_format_i18n(floatval($item['item_total_price']), 2)); ?></em></p>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    </div>
+    <?php endif; ?>
+</div>
+
+<?php
+// JavaScript for handling status update on this page
+// This reuses the existing AJAX endpoint.
+// Note: This script is output directly. In a full plugin, it would be in a separate .js file and enqueued.
+?>
+<script type="text/javascript">
+jQuery(document).ready(function($) {
+    $('#mobooking-single-save-status-btn').on('click', function() {
+        var $button = $(this);
+        var bookingId = $('#mobooking-single-booking-status-select').data('booking-id');
+        var newStatus = $('#mobooking-single-booking-status-select').val();
+        var $feedback = $('#mobooking-single-status-feedback');
+        var $currentStatusDisplay = $('#mobooking-current-status-display');
+
+        $feedback.text('<?php esc_js_e('Updating...', 'mobooking'); ?>').removeClass('success error');
+        $button.prop('disabled', true);
+
+        $.ajax({
+            url: ajaxurl, // WordPress AJAX URL
+            type: 'POST',
+            data: {
+                action: 'mobooking_update_booking_status',
+                nonce: '<?php echo wp_create_nonce('mobooking_dashboard_nonce'); // Assuming this nonce is still generally used for dashboard actions ?>',
+                booking_id: bookingId,
+                new_status: newStatus
+            },
+            success: function(response) {
+                if (response.success) {
+                    $feedback.text(response.data.message || '<?php esc_js_e('Status updated successfully!', 'mobooking'); ?>').addClass('success').removeClass('error');
+                    // Update current status display badge
+                    $currentStatusDisplay.text(newStatus.charAt(0).toUpperCase() + newStatus.slice(1).replace('-', ' '));
+                    $currentStatusDisplay.removeClassWild("mobooking-status-*").addClass("mobooking-status-" + newStatus);
+
+                } else {
+                    $feedback.text(response.data.message || '<?php esc_js_e('Error updating status.', 'mobooking'); ?>').addClass('error').removeClass('success');
+                }
+            },
+            error: function() {
+                $feedback.text('<?php esc_js_e('AJAX request failed.', 'mobooking'); ?>').addClass('error').removeClass('success');
+            },
+            complete: function() {
+                $button.prop('disabled', false);
+                 setTimeout(function() { $feedback.text(''); }, 5000);
+            }
+        });
+    });
+
+    // Helper to remove classes with wildcard
+    $.fn.removeClassWild = function(mask) {
+        return this.removeClass(function(index, cls) {
+            var re = mask.replace(/\*/g, '\\S+');
+            return (cls.match(new RegExp('\\b' + re + '', 'g')) || []).join(' ');
+        });
+    };
+});
+</script>

--- a/dashboard/page-bookings.php
+++ b/dashboard/page-bookings.php
@@ -50,6 +50,26 @@ $discounts_manager = new \MoBooking\Classes\Discounts($current_user_id);
 $notifications_manager = new \MoBooking\Classes\Notifications();
 $bookings_manager = new \MoBooking\Classes\Bookings($discounts_manager, $notifications_manager, $services_manager);
 
+// Basic router for single booking view
+if (isset($_GET['action']) && $_GET['action'] === 'view_booking' && isset($_GET['booking_id'])) {
+    $single_booking_id = intval($_GET['booking_id']);
+    // Pass necessary variables to the single booking page context
+    // $bookings_manager, $currency_symbol, $current_user_id are already available
+
+    // Attempt to include the single booking page template
+    // The actual file will be created in a later step.
+    $single_page_path = __DIR__ . '/page-booking-single.php';
+    if (file_exists($single_page_path)) {
+        include $single_page_path;
+        return; // Stop further processing of the list page
+    } else {
+        // Handle case where file doesn't exist yet, maybe show an error or fall through to list
+        // For now, we'll fall through, but ideally, this would be robust.
+         echo '<div class="notice notice-error"><p>Single booking page template not found.</p></div>';
+    }
+}
+
+
 if ($current_user_id) {
     // Fetch KPI data
     // Determine the user ID for fetching data (owner if current user is worker)
@@ -77,33 +97,46 @@ if ($current_user_id) {
     // get_bookings_by_tenant now correctly handles if $current_user_id is a worker
     $bookings_result = $bookings_manager->get_bookings_by_tenant($current_user_id, $default_args);
 
+    // Prepare table structure for initial bookings
     if (!empty($bookings_result['bookings'])) {
+        $initial_bookings_html .= '<div class="mobooking-table-responsive-wrapper">';
+        $initial_bookings_html .= '<table class="mobooking-table wp-list-table widefat fixed striped">';
+        $initial_bookings_html .= '<thead><tr>';
+        $initial_bookings_html .= '<th>' . esc_html__('Ref', 'mobooking') . '</th>';
+        $initial_bookings_html .= '<th>' . esc_html__('Customer', 'mobooking') . '</th>';
+        $initial_bookings_html .= '<th>' . esc_html__('Booked Date', 'mobooking') . '</th>';
+        $initial_bookings_html .= '<th>' . esc_html__('Total', 'mobooking') . '</th>';
+        $initial_bookings_html .= '<th>' . esc_html__('Status', 'mobooking') . '</th>';
+        $initial_bookings_html .= '<th>' . esc_html__('Actions', 'mobooking') . '</th>';
+        $initial_bookings_html .= '</tr></thead>';
+        $initial_bookings_html .= '<tbody>';
+
         foreach ($bookings_result['bookings'] as $booking) {
             $status_display = !empty($booking['status']) ? ucfirst(str_replace('-', ' ', $booking['status'])) : __('N/A', 'mobooking');
             $total_price_formatted = esc_html($currency_symbol . number_format_i18n(floatval($booking['total_price']), 2));
-            $created_at_formatted = date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($booking['created_at']));
             $booking_date_formatted = date_i18n(get_option('date_format'), strtotime($booking['booking_date']));
+            $booking_time_formatted = date_i18n(get_option('time_format'), strtotime($booking['booking_time'])); // Assuming booking_time is just time
 
-            // Note: Inline styles will be removed/replaced by classes in the CSS step
-            $initial_bookings_html .= '<div class="mobooking-booking-item mobooking-card">';
-            $initial_bookings_html .= '<div class="mobooking-card-header">';
-            $initial_bookings_html .= '<h3>' . __('Booking Ref:', 'mobooking') . ' ' . esc_html($booking['booking_reference']) . '</h3>';
-            $initial_bookings_html .= '<span class="mobooking-status-badge mobooking-status-' . esc_attr($booking['status']) . '">' . esc_html($status_display) . '</span>';
-            $initial_bookings_html .= '</div>'; // end card-header
-            $initial_bookings_html .= '<div class="mobooking-card-content">';
-            $initial_bookings_html .= '<p><strong>' . __('Customer:', 'mobooking') . '</strong> ' . esc_html($booking['customer_name']) . ' (' . esc_html($booking['customer_email']) . ')</p>';
-            $initial_bookings_html .= '<p><strong>' . __('Booked Date:', 'mobooking') . '</strong> ' . esc_html($booking_date_formatted) . ' at ' . esc_html($booking['booking_time']) . '</p>';
-            $initial_bookings_html .= '<p><strong>' . __('Total Price:', 'mobooking') . '</strong> ' . $total_price_formatted . '</p>';
-            $initial_bookings_html .= '<p class="mobooking-created-date"><strong>' . __('Created:', 'mobooking') . '</strong> ' . esc_html($created_at_formatted) . '</p>';
-            $initial_bookings_html .= '</div>'; // end card-content
-            $initial_bookings_html .= '<div class="mobooking-card-actions">';
-            $initial_bookings_html .= '<button class="button mobooking-view-booking-details-btn" data-booking-id="' . esc_attr($booking['booking_id']) . '">' . __('View Details', 'mobooking') . '</button>';
-            $initial_bookings_html .= '<button class="button mobooking-delete-booking-btn" data-booking-id="' . esc_attr($booking['booking_id']) . '">' . __('Delete', 'mobooking') . '</button>';
-            $initial_bookings_html .= '</div>'; // end card-actions
-            $initial_bookings_html .= '</div>'; // end booking-item
+            $details_page_url = admin_url('admin.php?page=mobooking&action=view_booking&booking_id=' . $booking['booking_id']);
+
+            $initial_bookings_html .= '<tr data-booking-id="' . esc_attr($booking['booking_id']) . '">';
+            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Ref', 'mobooking') . '">' . esc_html($booking['booking_reference']) . '</td>';
+            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Customer', 'mobooking') . '">' . esc_html($booking['customer_name']) . '<br><small>' . esc_html($booking['customer_email']) . '</small></td>';
+            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Booked Date', 'mobooking') . '">' . esc_html($booking_date_formatted . ' ' . $booking_time_formatted) . '</td>';
+            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Total', 'mobooking') . '">' . $total_price_formatted . '</td>';
+            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Status', 'mobooking') . '"><span class="mobooking-status-badge mobooking-status-' . esc_attr($booking['status']) . '">' . esc_html($status_display) . '</span></td>';
+            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Actions', 'mobooking') . '" class="mobooking-table-actions">';
+            $initial_bookings_html .= '<a href="' . esc_url($details_page_url) . '" class="button button-small">' . __('View Details', 'mobooking') . '</a> ';
+            $initial_bookings_html .= '<button class="button button-small mobooking-delete-booking-btn" data-booking-id="' . esc_attr($booking['booking_id']) . '">' . __('Delete', 'mobooking') . '</button>';
+            $initial_bookings_html .= '</td></tr>';
         }
+        $initial_bookings_html .= '</tbody></table>';
+        $initial_bookings_html .= '</div>'; // end mobooking-table-responsive-wrapper
+    } else {
+        $initial_bookings_html = '<p>' . __('No bookings found.', 'mobooking') . '</p>'; // Keep this if no bookings
+    }
 
-        // Basic pagination (JS will handle more complex pagination) - plan to restyle this too
+    // Basic pagination (JS will handle more complex pagination) - plan to restyle this too
         $total_pages = ceil($bookings_result['total_count'] / $bookings_result['per_page']);
         if ($total_pages > 1) {
             $initial_pagination_html .= '<div class="pagination-links">';
@@ -197,7 +230,7 @@ $booking_statuses = [
         </form>
     </div>
 
-    <div id="mobooking-bookings-list-container" class="mobooking-bookings-grid"> <?php // Grid for booking cards ?>
+    <div id="mobooking-bookings-list-container"> <?php // Container for the table or "no bookings" message ?>
         <?php echo $initial_bookings_html; // WPCS: XSS ok. Escaped above. ?>
     </div>
 
@@ -206,489 +239,28 @@ $booking_statuses = [
     </div>
 
 <script type="text/template" id="mobooking-booking-item-template">
-    <div class="mobooking-booking-item mobooking-card">
-        <div class="mobooking-card-header">
-            <h3><?php esc_html_e('Booking Ref:', 'mobooking'); ?> <%= booking_reference %></h3>
-            <span class="mobooking-status-badge mobooking-status-<%= status %>"><%= status_display %></span>
-        </div>
-        <div class="mobooking-card-content">
-            <p><strong><?php esc_html_e('Customer:', 'mobooking'); ?></strong> <%= customer_name %> (<%= customer_email %>)</p>
-            <p><strong><?php esc_html_e('Booked Date:', 'mobooking'); ?></strong> <%= booking_date %> at <%= booking_time %></p>
-            <p><strong><?php esc_html_e('Total Price:', 'mobooking'); ?></strong> <%= total_price_formatted %></p>
-            <p class="mobooking-created-date"><strong><?php esc_html_e('Created:', 'mobooking'); ?></strong> <%= created_at_formatted %></p>
-        </div>
-        <div class="mobooking-card-actions">
-            <button class="button mobooking-view-booking-details-btn" data-booking-id="<%= booking_id %>"><?php esc_html_e('View Details', 'mobooking'); ?></button>
-            <button class="button mobooking-delete-booking-btn" data-booking-id="<%= booking_id %>"><?php esc_html_e('Delete', 'mobooking'); ?></button>
-        </div>
-    </div>
+    <tr data-booking-id="<%= booking_id %>">
+        <td data-colname="<?php esc_attr_e('Ref', 'mobooking'); ?>"><%= booking_reference %></td>
+        <td data-colname="<?php esc_attr_e('Customer', 'mobooking'); ?>"><%= customer_name %><br><small><%= customer_email %></small></td>
+        <td data-colname="<?php esc_attr_e('Booked Date', 'mobooking'); ?>"><%= booking_date_formatted %> <%= booking_time_formatted %></td>
+        <td data-colname="<?php esc_attr_e('Total', 'mobooking'); ?>"><%= total_price_formatted %></td>
+        <td data-colname="<?php esc_attr_e('Status', 'mobooking'); ?>"><span class="mobooking-status-badge mobooking-status-<%= status %>"><%= status_display %></span></td>
+        <td data-colname="<?php esc_attr_e('Actions', 'mobooking'); ?>" class="mobooking-table-actions">
+            <a href="<%= details_page_url %>" class="button button-small"><?php esc_html_e('View Details', 'mobooking'); ?></a>
+            <button class="button button-small mobooking-delete-booking-btn" data-booking-id="<%= booking_id %>"><?php esc_html_e('Delete', 'mobooking'); ?></button>
+        </td>
+    </tr>
 </script>
 
-<div id="mobooking-booking-details-modal" class="mobooking-modal"> <?php // Modal structure remains, styling will be external ?>
-    <div class="mobooking-modal-content">
-        <button class="mobooking-modal-close">&times;</button> <?php // Changed span to button for better accessibility practice ?>
-        <h2 id="modal-booking-title"><?php esc_html_e('Booking Details', 'mobooking'); ?> - <span id="modal-booking-ref"></span></h2>
+<?php // The Modal HTML structure is now removed as per the new plan. ?>
 
-        <input type="hidden" id="modal-current-booking-id" value="">
+        <?php
+        // Temporary Styles block has been removed.
+        // All styles are now expected to be loaded from 'assets/css/dashboard-bookings-responsive.css'
+        // which should be enqueued by the plugin's main asset handling logic.
+        ?>
 
-        <?php // Temporary Styles - These should be moved to an enqueued CSS file: assets/css/dashboard-bookings-responsive.css ?>
-<style>
-/*
-==========================================================================
-General Page & ShadCN-like Card Styling
-==========================================================================
-*/
-
-/* Apply a base font stack similar to WordPress admin for consistency, can be overridden */
-body.wp-admin #wpbody-content .mobooking-bookings-page-wrapper {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-    font-size: 14px; /* Consistent base font size */
-    /* background-color: #f0f0f0; */ /* Light gray background for the page, typical in modern UIs - WP handles its own body bg */
-    /* padding: 20px; */ /* WP handles its own body padding */
-}
-
-.mobooking-bookings-page-wrapper {
-    max-width: 1600px; /* Max width for larger screens */
-    margin: 0 auto; /* Center the content */
-    padding: 1px 15px 15px 15px; /* Padding around the page content, 1px top to avoid margin collapse with WP header */
-    /* background-color: var(--wp-admin-theme-color-fresh, #f0f2f5); */ /* Match WP admin bg or a neutral one */
-}
-
-.mobooking-card {
-    background-color: #ffffff;
-    border: 1px solid #e2e8f0; /* Softer border color */
-    border-radius: 0.5rem; /* shadcn uses 0.5rem for cards */
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.03), 0 1px 2px 0 rgba(0, 0, 0, 0.02); /* Subtle shadow */
-    margin-bottom: 1.5rem;
-    padding: 1.5rem;
-}
-
-.mobooking-card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding-bottom: 1rem;
-    margin-bottom: 1rem;
-    border-bottom: 1px solid #e2e8f0;
-}
-
-.mobooking-card-header h3 {
-    margin: 0;
-    font-size: 1.125rem; /* 18px */
-    font-weight: 600;
-    line-height: 1.2;
-}
-
-.mobooking-card-content p {
-    margin-bottom: 0.5rem;
-    line-height: 1.6;
-}
-.mobooking-card-content p strong {
-    font-weight: 500;
-    color: #333;
-}
-
-.mobooking-card-actions {
-    margin-top: 1.5rem;
-    padding-top: 1rem;
-    border-top: 1px solid #e2e8f0;
-    display: flex;
-    gap: 0.5rem; /* Space between buttons */
-}
-.mobooking-card-actions .button {
-    margin-left: 0 !important; /* Override WP default button margin if any */
-}
-
-
-/*
-==========================================================================
-Page Header
-==========================================================================
-*/
-.mobooking-page-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1.5rem;
-    padding-bottom: 1rem;
-    border-bottom: 1px solid #e2e8f0;
-}
-.mobooking-page-header h1 {
-    font-size: 1.75rem; /* Larger page titles */
-    font-weight: 600;
-    margin: 0;
-}
-
-/*
-==========================================================================
-KPI Grid
-==========================================================================
-*/
-.mobooking-kpi-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-.mobooking-kpi-card {
-    background-color: #ffffff;
-    border: 1px solid #e2e8f0;
-    border-radius: 0.5rem;
-    padding: 1.25rem; /* 20px */
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.03), 0 1px 2px 0 rgba(0, 0, 0, 0.02);
-}
-
-.mobooking-kpi-card h4 {
-    margin-top: 0;
-    margin-bottom: 0.5rem;
-    font-size: 0.875rem; /* 14px */
-    font-weight: 500;
-    color: #4a5568; /* Gray-600 */
-}
-
-.mobooking-kpi-card p {
-    margin: 0;
-    font-size: 1.875rem; /* 30px */
-    font-weight: 600;
-    color: #1a202c; /* Gray-900 */
-}
-
-/*
-==========================================================================
-Filters Bar
-==========================================================================
-*/
-.mobooking-filters-bar.mobooking-card { /* This is a .mobooking-card now */
-    /* padding already handled by .mobooking-card */
-}
-
-.mobooking-filters-form {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem; /* Spacing between filter items/actions */
-    align-items: flex-end; /* Align items to bottom for better look with varied heights */
-}
-
-.mobooking-filter-item {
-    display: flex;
-    flex-direction: column; /* Stack label and input */
-    gap: 0.25rem; /* Space between label and input */
-    flex-grow: 1; /* Allow items to grow */
-    min-width: 150px; /* Minimum width before wrapping */
-}
-.mobooking-filter-item label {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: #4a5568;
-}
-.mobooking-filter-item select,
-.mobooking-filter-item input[type="text"],
-.mobooking-filter-item input[type="date"] { /* Assuming datepicker might become input type date */
-    padding: 0.5rem 0.75rem;
-    border: 1px solid #cbd5e0; /* Gray-300 */
-    border-radius: 0.375rem; /* Smaller radius for inputs */
-    font-size: 0.875rem;
-    width: 100%; /* Make inputs take full width of their flex item */
-    box-sizing: border-box;
-}
-.mobooking-filter-item input[type="text"].mobooking-datepicker {
-    /* Specific styles for datepicker if needed, otherwise inherits text input */
-}
-
-.mobooking-filter-actions {
-    display: flex;
-    gap: 0.5rem;
-    padding-top: 1.1em; /* Align with inputs if labels are above for WP context */
-}
-
-
-/*
-==========================================================================
-Bookings List / Grid
-==========================================================================
-*/
-.mobooking-bookings-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); /* Responsive cards */
-    gap: 1.5rem;
-}
-
-.mobooking-booking-item.mobooking-card {
-    /* General card styles already defined */
-    display: flex;
-    flex-direction: column; /* Stack header, content, actions */
-}
-.mobooking-booking-item .mobooking-card-content {
-    flex-grow: 1; /* Allow content to take available space */
-}
-
-.mobooking-created-date {
-    font-size: 0.8rem;
-    color: #718096; /* Gray-500 */
-}
-
-/* Status Badges */
-.mobooking-status-badge {
-    padding: 0.25em 0.6em;
-    font-size: 0.75rem; /* 12px */
-    font-weight: 500;
-    border-radius: 0.25rem; /* Pill like */
-    text-transform: capitalize;
-    line-height: 1;
-    white-space: nowrap;
-}
-.mobooking-status-pending { background-color: #feebc8; color: #9c4221; } /* Orange-200, Orange-700 */
-.mobooking-status-confirmed { background-color: #c6f6d5; color: #2f855a; } /* Green-200, Green-700 */
-.mobooking-status-completed { background-color: #bee3f8; color: #2c5282; } /* Blue-200, Blue-700 */
-.mobooking-status-cancelled { background-color: #fed7d7; color: #c53030; } /* Red-200, Red-700 */
-.mobooking-status-on-hold { background-color: #faf089; color: #b7791f; } /* Yellow-200, Yellow-700 */
-.mobooking-status-processing { background-color: #e9d8fd; color: #6b46c1; } /* Purple-200, Purple-700 */
-
-
-/*
-==========================================================================
-Pagination
-==========================================================================
-*/
-.mobooking-pagination {
-    margin-top: 2rem;
-    text-align: center;
-}
-.mobooking-pagination .page-numbers {
-    display: inline-block;
-    padding: 0.5rem 0.75rem;
-    margin: 0 0.25rem;
-    border: 1px solid #e2e8f0;
-    border-radius: 0.375rem;
-    color: #2d3748; /* Gray-700 */
-    text-decoration: none;
-    transition: background-color 0.2s, color 0.2s;
-}
-.mobooking-pagination .page-numbers:hover {
-    background-color: #edf2f7; /* Gray-100 */
-    border-color: #cbd5e0; /* Gray-300 */
-}
-.mobooking-pagination .page-numbers.current {
-    background-color: var(--wp-admin-theme-color, #2271b1); /* Primary blue or WP admin theme color */
-    color: #ffffff;
-    border-color: var(--wp-admin-theme-color, #2271b1);
-    font-weight: 600;
-}
-
-/*
-==========================================================================
-Modal Styling (replaces inline styles)
-==========================================================================
-*/
-.mobooking-modal {
-    display: none; /* Hidden by default */
-    position: fixed;
-    z-index: 1050; /* High z-index */
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto; /* Enable scroll if needed */
-    background-color: rgba(0, 0, 0, 0.6); /* Darker overlay */
-}
-
-.mobooking-modal-content {
-    background-color: #ffffff;
-    margin: 5% auto; /* Centered, more top margin */
-    padding: 2rem; /* More padding */
-    border: none; /* Remove border, rely on shadow */
-    width: 90%;
-    max-width: 700px; /* Max width */
-    border-radius: 0.5rem; /* Consistent with cards */
-    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05); /* ShadCN Dialog shadow */
-    position: relative;
-    display: flex;
-    flex-direction: column;
-}
-
-.mobooking-modal-close {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    color: #a0aec0; /* Gray-500 */
-    font-size: 1.5rem; /* Larger close icon */
-    font-weight: normal; /* Not bold */
-    line-height: 1;
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0.25rem;
-}
-.mobooking-modal-close:hover {
-    color: #1a202c; /* Gray-900 */
-}
-
-.mobooking-modal .modal-section {
-    margin-bottom: 1.5rem;
-    padding-bottom: 1.5rem;
-    border-bottom: 1px solid #e2e8f0; /* Softer separator */
-}
-.mobooking-modal .modal-section:last-child {
-    border-bottom: none;
-    margin-bottom: 0;
-    padding-bottom: 0;
-}
-
-.mobooking-modal h2 { /* Modal Title */
-    margin-top: 0;
-    margin-bottom: 1.5rem;
-    font-size: 1.25rem; /* 20px */
-    font-weight: 600;
-    color: #1a202c;
-}
-.mobooking-modal h4 { /* Section Titles */
-    font-size: 1rem; /* 16px */
-    font-weight: 600;
-    color: #2d3748;
-    margin-top: 0;
-    margin-bottom: 0.75rem;
-}
-
-#modal-services-items-list ul {
-    padding-left: 1rem; /* Less indent */
-    margin-top: 0.5rem;
-    list-style: none;
-}
-#modal-services-items-list li {
-    margin-bottom: 0.5rem;
-    font-size: 0.875rem;
-}
-#modal-services-items-list .option-list {
-    padding-left: 1rem;
-    font-size: 0.8rem;
-    color: #718096;
-}
-
-#modal-booking-status-select {
-    padding: 0.5rem 0.75rem;
-    border: 1px solid #cbd5e0;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    margin-right: 0.5rem;
-    min-width: 180px;
-}
-#modal-status-feedback {
-    font-style: italic;
-    font-size: 0.875rem;
-    color: #4a5568;
-}
-
-/* Responsive adjustments */
-@media (max-width: 782px) { /* WordPress admin breakpoint */
-    .mobooking-kpi-grid {
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-        gap: 1rem;
-    }
-    .mobooking-kpi-card p {
-        font-size: 1.5rem; /* Smaller KPI values on mobile */
-    }
-
-    .mobooking-filters-form {
-        flex-direction: column;
-        align-items: stretch; /* Make filter items take full width */
-    }
-    .mobooking-filter-item {
-        min-width: 100%; /* Full width on mobile */
-    }
-    .mobooking-filter-actions {
-        padding-top: 0.5rem;
-        justify-content: flex-start;
-    }
-
-    .mobooking-bookings-grid {
-        grid-template-columns: 1fr; /* Single column for booking cards */
-        gap: 1rem;
-    }
-    .mobooking-card {
-        padding: 1rem;
-    }
-    .mobooking-card-header h3 {
-        font-size: 1rem;
-    }
-
-    .mobooking-modal-content {
-        margin: 5% auto;
-        width: 95%;
-        padding: 1.5rem;
-    }
-}
-
-@media (max-width: 480px) {
-    .mobooking-page-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.75rem;
-    }
-    .mobooking-page-header h1 {
-        font-size: 1.5rem;
-    }
-    .mobooking-kpi-card {
-        padding: 1rem;
-    }
-     .mobooking-kpi-card h4 {
-        font-size: 0.8rem;
-    }
-    .mobooking-kpi-card p {
-        font-size: 1.3rem;
-    }
-}
-
-/* WordPress Button Overrides (if necessary, for consistency) */
-.mobooking-bookings-page-wrapper .button {
-    /* Example: Standardize button padding/height if WP defaults are inconsistent */
-    /* padding: 0.5rem 1rem; */
-    /* line-height: 1.5; */
-    border-radius: 0.375rem; /* ShadCN often uses rounded buttons */
-}
-.mobooking-bookings-page-wrapper .button-primary {
-    /* background-color: var(--wp-admin-theme-color, #2271b1); */
-    /* border-color: var(--wp-admin-theme-color, #2271b1); */
-    /* color: #fff; */
-}
-/* Add more specific overrides if default WP admin button styles clash too much */
-
-/* Ensure delete button has a distinct, ShadCN-like destructive style */
-.mobooking-card-actions .mobooking-delete-booking-btn {
-    background-color: #fed7d7; /* Red-200 */
-    border-color: #fed7d7;
-    color: #c53030; /* Red-700 */
-    font-weight: 500;
-}
-.mobooking-card-actions .mobooking-delete-booking-btn:hover,
-.mobooking-card-actions .mobooking-delete-booking-btn:focus {
-    background-color: #fbb6b6; /* Red-300 */
-    border-color: #fbb6b6;
-    color: #9b2c2c; /* Red-800 */
-}
-
-/* Ensure primary action buttons in modal are styled consistently */
-#modal-save-status-btn.button-primary {
-   /* Already inherits general button styles, WP might handle this well */
-}
-
-/* Helper class if needed for visually hidden labels (for accessibility) */
-.mobooking-visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-}
-</style>
-        <?php // End Temporary Styles ?>
-
-        <div class="modal-section">
-            <h4><?php esc_html_e('Update Status', 'mobooking'); ?></h4>
+        <?php // The modal sections are also removed as the modal itself is gone. ?>
             <select id="modal-booking-status-select" style="min-width:150px;"></select> <?php // Options populated by JS ?>
             <button id="modal-save-status-btn" class="button button-primary button-small"><?php esc_html_e('Save Status', 'mobooking'); ?></button>
             <span id="modal-status-feedback" style="margin-left:10px; font-style:italic;"></span>


### PR DESCRIPTION
- Changed bookings list display from cards to a responsive table.
- "View Details" action now navigates to a new, separate page for full booking details instead of opening a modal.
- Created `dashboard/page-booking-single.php` for the booking details view, including status update functionality.
- Implemented routing in `dashboard/page-bookings.php` to conditionally display either the list or single booking view.
- Updated `assets/js/dashboard-bookings.js`:
    - Removed all JavaScript related to the old modal.
    - Adjusted dynamic list rendering for table rows.
    - Updated delete functionality for table structure.
- Updated `assets/css/dashboard-bookings-responsive.css`:
    - Removed styles for old card list and modal.
    - Added styles for the new responsive table and single details page.
    - Ensured consistent ShadCN-like styling.
- Outlined manual test procedures for verification.