### PR TITLE
Fix: Correct tenant_id variable in wp_localize_script for public book…

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -170,7 +170,7 @@ function mobooking_scripts() {
         wp_localize_script('mobooking-booking-form', 'mobooking_booking_form_params', array(
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('mobooking_booking_form_nonce'),
-            'tenant_id' => $tenant_id_on_page,
+            'tenant_id' => $effective_tenant_id_for_public_form,
             // 'currency_symbol' => $public_form_currency_symbol, // REMOVED
             // 'currency_position' => $public_form_currency_position, // REMOVED
             'currency_code' => $public_form_currency_code,


### PR DESCRIPTION
…ing form

Ensures the correctly resolved tenant_id (from slug or tid parameter) is passed to the booking-form.js. Previously, an undefined variable was used, causing the tenant_id to be null/0 in JS and breaking the form's first step.

Also provided comprehensive setup instructions for the public booking form.