### PR TITLE
Standardize booking form URL and embed link structure

### DIFF
--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -532,7 +532,8 @@ Please review this booking in your dashboard: {{admin_booking_link}}",
     public function get_public_booking_url(int $user_id): string {
         $business_slug = $this->get_setting($user_id, 'bf_business_slug', '');
         if (!empty($business_slug)) {
-            return trailingslashit(site_url()) . $business_slug . '/booking/';
+            // Use the new standardized URL structure
+            return trailingslashit(site_url()) . 'bookings/' . $business_slug . '/';
         }
         return '';
     }

--- a/dashboard/page-booking-form.php
+++ b/dashboard/page-booking-form.php
@@ -31,7 +31,8 @@ if (empty($current_slug) && !empty($biz_settings['biz_name'])) {
 
 $public_booking_url = '';
 if (!empty($current_slug)) {
-    $public_booking_url = trailingslashit(site_url()) . esc_attr($current_slug) . '/booking/';
+    // Use the new standardized URL structure
+    $public_booking_url = trailingslashit(site_url()) . 'bookings/' . esc_attr($current_slug) . '/';
 }
 
 ?>
@@ -61,7 +62,7 @@ if (!empty($current_slug)) {
                         <input name="bf_business_slug" type="text" id="bf_business_slug" value="<?php echo esc_attr($current_slug); ?>" class="regular-text">
                         <p class="description">
                             <?php esc_html_e('Unique slug for your public booking page URL (e.g., your-business-name). It will be used like: ', 'mobooking'); ?>
-                            <code><?php echo trailingslashit(site_url()); ?>your-business-slug/booking/</code>
+                            <code><?php echo trailingslashit(site_url()); ?>bookings/your-business-slug/</code>
                         </p>
                         <p class="description"><?php esc_html_e('Changing this will change your public booking form URL. Only use lowercase letters, numbers, and hyphens.', 'mobooking'); ?></p>
                         <?php if (!empty($public_booking_url)): ?>
@@ -537,8 +538,9 @@ jQuery(document).ready(function($) {
     function updateShareableLinks(slug) {
         const sanitizedSlug = slug.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '');
         if (sanitizedSlug) {
-            const publicLink = baseSiteUrl + sanitizedSlug + '/booking/';
-            const embedCode = `<iframe src="${publicLink}" title="Booking Form" style="width:100%; height:800px; border:1px solid #ccc;"></iframe>`;
+            const publicLink = baseSiteUrl + 'bookings/' + sanitizedSlug + '/';
+            const embedLink = baseSiteUrl + 'embed-booking/' + sanitizedSlug + '/'; // New embed link structure
+            const embedCode = `<iframe src="${embedLink}" title="Booking Form" style="width:100%; height:800px; border:1px solid #ccc;"></iframe>`;
             
             publicLinkInput.val(publicLink);
             embedCodeTextarea.val(embedCode);
@@ -554,7 +556,8 @@ jQuery(document).ready(function($) {
             }
             
             // Update preview link if it exists
-            const previewLink = $('a[href*="/booking/"]');
+            // Ensure we target the correct preview link associated with the public URL input field
+            const previewLink = publicLinkInput.closest('td').find('a[target="_blank"].button-secondary');
             if (previewLink.length) {
                 previewLink.attr('href', publicLink);
             }


### PR DESCRIPTION
- Updated public booking URL to `[site_url]/bookings/[slug]/`.
- Updated embed booking URL to `[site_url]/embed-booking/[slug]/`.
- Modified `dashboard/page-booking-form.php` (PHP and inline JS) to generate and display these new URL formats.
- Updated `classes/Settings.php` (method `get_public_booking_url`) to use the new public URL format.
- Verified that `assets/js/dashboard-booking-form-settings.js` already aligns with the new structure.
- Reviewed and confirmed the data saving mechanism in `Settings.php` is robust for all booking form settings, including the slug.