### PR TITLE
feat: Revise registration and login pages with new requirements

### DIFF
--- a/assets/css/auth-pages.css
+++ b/assets/css/auth-pages.css
@@ -1,0 +1,359 @@
+/* assets/css/auth-pages.css */
+
+/* Full page container for auth pages */
+.mobooking-auth-page-container {
+    display: flex;
+    min-height: 100vh;
+    width: 100%;
+    background-color: hsl(210 40% 98%); /* bg-muted */
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+/* Grid container for the two columns */
+.mobooking-auth-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    width: 100%;
+    max-width: 1280px;
+    margin: auto;
+    box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1), 0 10px 10px -5px rgba(0,0,0,0.04); /* shadow-xl */
+    overflow: hidden;
+    border-radius: 0.75rem; /* rounded-lg */
+}
+
+/* Left column: Illustration/Image */
+.mobooking-auth-image-column {
+    background-color: hsl(222.2 47.4% 11.2%); /* bg-slate-900 (primary dark) */
+    background-size: cover;
+    background-position: center;
+    display: flex;
+    flex-direction: column; /* Stack content vertically */
+    align-items: center;
+    justify-content: center;
+    padding: 2.5rem; /* p-10 */
+    color: hsl(0 0% 100%);
+}
+
+.mobooking-auth-image-column .placeholder-content {
+    text-align: center;
+}
+.mobooking-auth-image-column .placeholder-content h1 {
+    font-size: 1.875rem; /* text-3xl */
+    font-weight: 700; /* font-bold */
+    color: hsl(0 0% 100%);
+    margin-bottom: 1rem; /* mb-4 */
+}
+.mobooking-auth-image-column .placeholder-content p {
+    font-size: 0.875rem; /* text-sm */
+    color: hsl(215 20.2% 65.1%); /* text-slate-400 (muted-foreground dark) */
+    line-height: 1.5;
+}
+
+/* Right column: Form content */
+.mobooking-auth-form-column {
+    background-color: hsl(0 0% 100%); /* bg-card (white) */
+    padding: 2.5rem; /* p-10 */
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    overflow-y: auto; /* For smaller heights if form is long */
+}
+
+.mobooking-auth-form-wrapper {
+    max-width: 400px;
+    width: 100%;
+    margin: 0 auto;
+}
+
+.mobooking-auth-form-wrapper h2 {
+    font-size: 1.5rem; /* text-2xl */
+    font-weight: 600; /* font-semibold */
+    color: hsl(222.2 84% 4.9%); /* text-card-foreground (primary text) */
+    margin-bottom: 1.5rem; /* mb-6 */
+    text-align: center;
+    letter-spacing: -0.025em; /* tracking-tight */
+}
+.mobooking-auth-form-wrapper h3 { /* For step titles */
+    font-size: 1.125rem; /* text-lg */
+    font-weight: 500; /* font-medium */
+    color: hsl(222.2 84% 4.9%);
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid hsl(214.3 31.8% 91.4%); /* border */
+}
+
+
+/* Input field styling (based on shadcn/ui Input) */
+.mobooking-auth-form-wrapper .input {
+    display: flex;
+    height: 2.5rem; /* h-10 */
+    width: 100%;
+    border-radius: 0.375rem; /* rounded-md */
+    border: 1px solid hsl(214.3 31.8% 91.4%); /* border-input */
+    background-color: hsl(0 0% 100%); /* bg-background */
+    padding: 0.5rem 0.75rem; /* px-3 py-2 */
+    font-size: 0.875rem; /* text-sm */
+    color: hsl(222.2 84% 4.9%);
+    line-height: 1.25rem; /* leading-5 (approx) */
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+.mobooking-auth-form-wrapper .input::placeholder {
+    color: hsl(215.4 16.3% 46.9%); /* text-muted-foreground */
+}
+.mobooking-auth-form-wrapper .input:focus {
+    outline: none;
+    border-color: hsl(221.2 83.2% 53.3%); /* ring-ring (focus) */
+    box-shadow: 0 0 0 2px hsl(221.2 83.2% 53.3% / 0.4); /* focus ring with opacity */
+}
+
+/* Button styling (based on shadcn/ui Button) */
+.mobooking-auth-form-wrapper .button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    border-radius: 0.375rem; /* rounded-md */
+    font-size: 0.875rem; /* text-sm */
+    font-weight: 500; /* font-medium */
+    transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, color 0.15s ease-in-out;
+    cursor: pointer;
+    border: 1px solid transparent;
+    padding: 0.5rem 1rem; /* h-10 px-4 py-2 (approx) */
+    height: 2.5rem;
+    text-decoration: none;
+    line-height: 1.25rem;
+}
+.mobooking-auth-form-wrapper .button:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px hsl(221.2 83.2% 53.3% / 0.4); /* focus ring */
+}
+.mobooking-auth-form-wrapper .button.button-primary {
+    background-color: hsl(222.2 47.4% 11.2%); /* bg-primary (dark blue) */
+    color: hsl(210 40% 98%); /* text-primary-foreground (light) */
+    border-color: hsl(222.2 47.4% 11.2%);
+}
+.mobooking-auth-form-wrapper .button.button-primary:hover {
+    background-color: hsl(222.2 47.4% 11.2% / 0.9); /* bg-primary/90 */
+}
+.mobooking-auth-form-wrapper .button:not(.button-primary) { /* Secondary/Default button */
+    background-color: hsl(0 0% 100%); /* bg-background */
+    border-color: hsl(214.3 31.8% 91.4%); /* border-input */
+    color: hsl(222.2 84% 4.9%); /* text-accent-foreground */
+}
+.mobooking-auth-form-wrapper .button:not(.button-primary):hover {
+    background-color: hsl(210 40% 96.1%); /* bg-accent */
+    color: hsl(222.2 84% 4.9%); /* text-accent-foreground */
+}
+
+
+/* Links below the form */
+.mobooking-auth-links {
+    margin-top: 1.5rem; /* mt-6 */
+    text-align: center;
+    font-size: 0.875rem; /* text-sm */
+}
+.mobooking-auth-links p {
+    margin-bottom: 0.25rem; /* Minimal spacing between links */
+}
+.mobooking-auth-links a {
+    color: hsl(221.2 83.2% 53.3%); /* text-primary */
+    text-decoration: none;
+    font-weight: 500; /* font-medium */
+}
+.mobooking-auth-links a:hover {
+    text-decoration: underline;
+}
+
+/* Responsive adjustments */
+@media (max-width: 992px) {
+    .mobooking-auth-grid {
+        grid-template-columns: 1fr;
+        max-width: 500px;
+        margin: 2rem auto;
+        border-radius: 0.5rem;
+    }
+    .mobooking-auth-image-column {
+        min-height: 200px;
+        /* display: none; */ /* Option: hide image on smaller screens */
+    }
+    .mobooking-auth-form-column {
+        padding: 2rem;
+    }
+}
+@media (max-width: 576px) {
+    .mobooking-auth-page-container {
+        padding: 1rem; /* Add padding to page itself on mobile */
+    }
+    .mobooking-auth-grid {
+        margin: 1rem auto;
+        box-shadow: none; /* Remove shadow on very small screens if it looks odd */
+        border-radius: 0.375rem;
+    }
+    .mobooking-auth-image-column {
+         display: none; /* Hide image column on very small screens */
+    }
+    .mobooking-auth-form-column {
+        padding: 1.5rem;
+    }
+    .mobooking-auth-form-wrapper h2 {
+        font-size: 1.25rem; /* text-xl */
+        margin-bottom: 1rem;
+    }
+}
+
+/* General form element layout */
+.mobooking-auth-form-wrapper .input,
+.mobooking-auth-form-wrapper .button.button-primary[type="submit"] { /* Full width only for main submit button */
+    width: 100%;
+}
+.mobooking-auth-form-wrapper p {
+    margin-bottom: 1rem; /* mb-4 */
+}
+.mobooking-auth-form-wrapper p.login-remember { /* Specific for remember me checkbox */
+    display: flex;
+    align-items: center;
+    margin-bottom: 1.25rem; /* mb-5 */
+}
+.mobooking-auth-form-wrapper p.login-remember label {
+    font-weight: 400; /* normal */
+    font-size: 0.875rem; /* text-sm */
+    margin-bottom: 0;
+    margin-left: 0.5rem; /* ml-2 */
+    color: hsl(215.4 16.3% 46.9%);
+}
+.mobooking-auth-form-wrapper p.login-remember input[type="checkbox"] {
+    height: 1rem; width: 1rem; /* h-4 w-4 */
+    border-radius: 0.25rem; /* rounded-sm */
+    border-color: hsl(214.3 31.8% 91.4%); /* border-primary */
+}
+
+.mobooking-auth-form-wrapper p label:not(.login-remember label) {
+    display: block;
+    margin-bottom: 0.5rem; /* mb-2 */
+    font-weight: 500; /* font-medium */
+    font-size: 0.875rem; /* text-sm */
+    color: hsl(222.2 84% 4.9%);
+}
+.mobooking-auth-form-wrapper small {
+    font-size: 0.75rem; /* text-xs */
+    color: hsl(215.4 16.3% 46.9%); /* text-muted-foreground */
+    display: block;
+    margin-top: 0.375rem; /* mt-1.5 */
+}
+
+/* Progress bar styling */
+#mobooking-progress-bar {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+    gap: 0.5rem;
+}
+.mobooking-progress-step {
+    flex: 1;
+    text-align: center;
+    padding: 0.5rem 0.25rem;
+    border: 1px solid hsl(214.3 31.8% 91.4%);
+    border-radius: 0.375rem;
+    background-color: hsl(0 0% 100%);
+    color: hsl(215.4 16.3% 46.9%);
+    font-size: 0.8rem;
+    transition: all 0.2s ease-in-out;
+}
+.mobooking-progress-step.active {
+    background-color: hsl(222.2 47.4% 11.2%); /* bg-primary */
+    color: hsl(210 40% 98%); /* text-primary-foreground */
+    border-color: hsl(222.2 47.4% 11.2%);
+    font-weight: 500;
+}
+/* Step transitions */
+.mobooking-register-step {
+    opacity: 0;
+    transform: translateY(10px);
+    transition: opacity 0.3s ease-out, transform 0.3s ease-out;
+    display: none;
+    visibility: hidden;
+}
+.mobooking-register-step.active {
+    opacity: 1;
+    transform: translateY(0);
+    display: block;
+    visibility: visible;
+}
+.form-navigation {
+    margin-top: 1.5rem; /* mt-6 */
+    display: flex;
+    justify-content: space-between;
+}
+.form-navigation .button {
+    min-width: 100px;
+}
+
+
+/* Error and Success Messages */
+#mobooking-register-message,
+#mobooking-login-message {
+    padding: 0.75rem 1rem; /* p-3 */
+    margin-top: 1rem; /* mt-4 */
+    border-radius: 0.375rem; /* rounded-md */
+    font-size: 0.875rem; /* text-sm */
+    text-align: center;
+    border-width: 1px;
+    border-style: solid;
+}
+#mobooking-register-message.error,
+#mobooking-login-message.error {
+    color: hsl(0 72.2% 50.6%); /* text-destructive */
+    background-color: hsl(0 100% 98%); /* destructive/10: #fff1f1 or similar */
+    border-color: hsl(0 84.2% 60.2%); /* border-destructive */
+}
+#mobooking-register-message.success,
+#mobooking-login-message.success {
+    color: hsl(142.1 70.6% 35.3%); /* Adjusted for better contrast on light bg */
+    background-color: hsl(145 75% 96.3%); /* Light green */
+    border-color: hsl(142.1 70.6% 45.3%);
+}
+
+/* Field specific error message styling */
+.field-error {
+    color: hsl(0 72.2% 50.6%);
+    font-size: 0.8rem;
+    margin-top: 0.25rem;
+}
+.input-error {
+    border-color: hsl(0 84.2% 60.2%) !important;
+}
+.input-error:focus {
+    border-color: hsl(0 84.2% 60.2%) !important;
+    box-shadow: 0 0 0 2px hsl(0 84.2% 60.2% / 0.4) !important;
+}
+
+/* Confirmation step styling */
+#mobooking-confirmation-details p {
+    margin-bottom: 0.75rem;
+    font-size: 0.9rem;
+    color: hsl(215.4 16.3% 46.9%); /* text-muted-foreground */
+}
+#mobooking-confirmation-details p strong {
+    color: hsl(222.2 84% 4.9%); /* text-foreground */
+    margin-right: 0.5rem;
+    font-weight: 500;
+}
+
+/* Hide default theme header/footer on these pages */
+body.page-template-page-login #page > #masthead,
+body.page-template-page-login #page > #colophon,
+body.page-template-page-register #page > #masthead,
+body.page-template-page-register #page > #colophon {
+    display: none;
+}
+
+body.page-template-page-login #page,
+body.page-template-page-register #page,
+body.page-template-page-login #content,
+body.page-template-page-register #content {
+    padding: 0;
+    margin: 0;
+    max-width: none;
+}
+
+```

--- a/classes/Routes/BookingFormRouter.php
+++ b/classes/Routes/BookingFormRouter.php
@@ -217,7 +217,7 @@ class BookingFormRouter {
     /**
      * Get user ID by business slug with enhanced error handling
      */
-    private function get_user_id_by_slug($slug) {
+    public static function get_user_id_by_slug($slug) { // Changed to public static
         global $wpdb;
 
         if (empty($slug)) {

--- a/front-page.php
+++ b/front-page.php
@@ -654,7 +654,10 @@ get_header();
                     <li><a href="#pricing">Pricing</a></li>
                     <li><a href="#testimonials">Reviews</a></li>
                 </ul>
-                <a href="/dashboard" class="btn btn-primary btn-sm">Get Started</a>
+                <div style="display: flex; gap: 0.75rem;">
+                    <a href="<?php echo esc_url(home_url('/login/')); ?>" class="btn btn-outline btn-sm">Login</a>
+                    <a href="<?php echo esc_url(home_url('/register/')); ?>" class="btn btn-primary btn-sm">Sign Up</a>
+                </div>
                 <button class="mobile-menu-toggle">☰</button>
             </nav>
         </div>
@@ -677,8 +680,8 @@ get_header();
                 </p>
 
                 <div class="hero-actions slide-up delay-200">
-                    <a href="/dashboard" class="btn btn-primary btn-xl">Start Free Trial</a>
-                    <a href="/dashboard" class="btn btn-outline btn-xl">Book Demo</a>
+                    <a href="<?php echo esc_url(home_url('/register/')); ?>" class="btn btn-primary btn-xl">Start Free Trial</a>
+                    <a href="/dashboard" class="btn btn-outline btn-xl">Book Demo</a> <!-- Assuming /dashboard or a contact page for demo -->
                 </div>
 
                 <div class="hero-stats fade-in delay-300">
@@ -827,7 +830,7 @@ get_header();
                                 <li>Customer management</li>
                                 <li>Basic integrations</li>
                             </ul>
-                            <a href="/dashboard" class="btn btn-outline btn-lg" style="width: 100%;">Choose Starter</a>
+                            <a href="<?php echo esc_url(home_url('/register/')); ?>" class="btn btn-outline btn-lg" style="width: 100%;">Choose Starter</a>
                         </div>
                     </div>
 
@@ -848,7 +851,7 @@ get_header();
                                 <li>Discount codes & promotions</li>
                                 <li>WooCommerce & Stripe integration</li>
                             </ul>
-                            <a href="/dashboard" class="btn btn-primary btn-lg" style="width: 100%;">Choose Professional</a>
+                            <a href="<?php echo esc_url(home_url('/register/')); ?>" class="btn btn-primary btn-lg" style="width: 100%;">Choose Professional</a>
                         </div>
                     </div>
 
@@ -868,7 +871,7 @@ get_header();
                                 <li>Custom integrations</li>
                                 <li>Advanced security features</li>
                             </ul>
-                            <a href="/dashboard" class="btn btn-outline btn-lg" style="width: 100%;">Contact Sales</a>
+                            <a href="/dashboard" class="btn btn-outline btn-lg" style="width: 100%;">Contact Sales</a> <!-- Assuming /dashboard or contact page -->
                         </div>
                     </div>
                 </div>
@@ -1025,8 +1028,8 @@ get_header();
                 </p>
 
                 <div class="hero-actions slide-up delay-200">
-                    <a href="/dashboard" class="btn btn-primary btn-xl">Start Free Trial</a>
-                    <a href="/dashboard" class="btn btn-outline btn-xl">Schedule Demo</a>
+                    <a href="<?php echo esc_url(home_url('/register/')); ?>" class="btn btn-primary btn-xl">Start Free Trial</a>
+                    <a href="/dashboard" class="btn btn-outline btn-xl">Schedule Demo</a> <!-- Assuming /dashboard or contact page -->
                 </div>
 
                 <p style="margin-top: 1rem; font-size: 0.875rem; color: hsl(var(--muted-foreground));">

--- a/functions.php
+++ b/functions.php
@@ -83,6 +83,9 @@ function mobooking_scripts() {
     wp_enqueue_style( 'mobooking-style', get_stylesheet_uri(), array('mobooking-reset'), MOBOOKING_VERSION );
 
     if ( is_page_template( 'page-login.php' ) || is_page_template('page-register.php') ) {
+        // Enqueue the new auth pages specific CSS
+        wp_enqueue_style( 'mobooking-auth-pages', MOBOOKING_THEME_URI . 'assets/css/auth-pages.css', array('mobooking-style'), MOBOOKING_VERSION );
+
         wp_enqueue_script( 'mobooking-auth', MOBOOKING_THEME_URI . 'assets/js/auth.js', array( 'jquery' ), MOBOOKING_VERSION, true );
         wp_localize_script(
             'mobooking-auth',

--- a/page-login.php
+++ b/page-login.php
@@ -31,52 +31,53 @@ if ( is_user_logged_in() ) {
     // exit;
 }
 
-get_header();
+get_header(); // This will be hidden by CSS in auth-pages.css for these templates
 ?>
 
-<main id="main" class="site-main">
-    <div id="mobooking-login-form-container" class="mobooking-auth-form-wrapper">
-        <h2><?php esc_html_e( 'Business Owner Login', 'mobooking' ); ?></h2>
-        <form id="mobooking-login-form">
-            <p class="login-username">
-                <label for="mobooking-user-login"><?php esc_html_e( 'Email Address', 'mobooking' ); ?></label>
-                <input type="text" name="log" id="mobooking-user-login" class="input" value="" size="20" />
-            </p>
-            <p class="login-password">
-                <label for="mobooking-user-pass"><?php esc_html_e( 'Password', 'mobooking' ); ?></label>
-                <input type="password" name="pwd" id="mobooking-user-pass" class="input" value="" size="20" />
-            </p>
-            <?php // Nonce is handled by assets/js/auth.js via localized script parameters ?>
-            <p class="login-remember"><label><input name="rememberme" type="checkbox" id="mobooking-rememberme" value="forever" /> <?php esc_html_e( 'Remember Me', 'mobooking' ); ?></label></p>
-            <p class="login-submit">
-                <input type="submit" name="wp-submit" id="mobooking-wp-submit" class="button button-primary" value="<?php esc_attr_e( 'Log In', 'mobooking' ); ?>" />
-                <input type="hidden" name="redirect_to" value="<?php echo esc_url( home_url( '/dashboard/' ) ); // Adjust as needed ?>" />
-            </p>
-            <div id="mobooking-login-message" style="display:none;"></div>
-        </form>
-        <p>
-            <a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'mobooking' ); ?></a>
-        </p>
-        <p>
-            <?php // Placeholder for registration link - will point to a custom registration page or process ?>
-            <a href="<?php echo esc_url( home_url( '/register/' ) ); // Placeholder ?>"><?php esc_html_e( 'Don\'t have an account? Register', 'mobooking' ); ?></a>
-        </p>
+<div class="mobooking-auth-page-container">
+    <div class="mobooking-auth-grid">
+        <div class="mobooking-auth-image-column">
+            <div class="placeholder-content">
+                 <!-- You can replace this with an <img> tag or more complex HTML -->
+                <h1><?php bloginfo('name'); ?></h1>
+                <p><?php esc_html_e('Manage your bookings efficiently and effectively.', 'mobooking'); ?></p>
+            </div>
+        </div>
+        <div class="mobooking-auth-form-column">
+            <main id="main" class="site-main">
+                <div id="mobooking-login-form-container" class="mobooking-auth-form-wrapper">
+                    <h2><?php esc_html_e( 'Business Owner Login', 'mobooking' ); ?></h2>
+                    <form id="mobooking-login-form">
+                        <p class="login-username">
+                            <label for="mobooking-user-login"><?php esc_html_e( 'Email Address', 'mobooking' ); ?></label>
+                            <input type="text" name="log" id="mobooking-user-login" class="input" value="" size="20" required />
+                        </p>
+                        <p class="login-password">
+                            <label for="mobooking-user-pass"><?php esc_html_e( 'Password', 'mobooking' ); ?></label>
+                            <input type="password" name="pwd" id="mobooking-user-pass" class="input" value="" size="20" required />
+                        </p>
+                        <?php // Nonce is handled by assets/js/auth.js via localized script parameters ?>
+                        <p class="login-remember"><label><input name="rememberme" type="checkbox" id="mobooking-rememberme" value="forever" /> <?php esc_html_e( 'Remember Me', 'mobooking' ); ?></label></p>
+                        <p class="login-submit">
+                            <input type="submit" name="wp-submit" id="mobooking-wp-submit" class="button button-primary" value="<?php esc_attr_e( 'Log In', 'mobooking' ); ?>" />
+                            <input type="hidden" name="redirect_to" value="<?php echo esc_url( home_url( '/dashboard/' ) ); // Adjust as needed ?>" />
+                        </p>
+                        <div id="mobooking-login-message" style="display:none;"></div>
+                    </form>
+                    <div class="mobooking-auth-links">
+                        <p>
+                            <a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'mobooking' ); ?></a>
+                        </p>
+                        <p>
+                            <?php esc_html_e( 'Don\'t have an account?', 'mobooking' ); ?>
+                            <a href="<?php echo esc_url( home_url( '/register/' ) ); ?>"><?php esc_html_e( 'Register', 'mobooking' ); ?></a>
+                        </p>
+                    </div>
+                </div>
+            </main><!-- #main -->
+        </div>
     </div>
-</main><!-- #main -->
+</div>
 
 <?php
-// We might not want the standard footer on the login page, or a simplified one.
-// For now, including the standard one.
-?>
-<style>
-    .mobooking-auth-form-wrapper { max-width: 500px; margin: 2rem auto; padding: 2rem; background: #fff; border: 1px solid #e2e8f0; border-radius: 0.5rem; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06); }
-    .mobooking-auth-form-wrapper h2 { margin-top: 0; margin-bottom: 1.5rem; font-size: 1.5rem; text-align: center; }
-    .mobooking-auth-form-wrapper .input { margin-bottom: 1rem; }
-    .mobooking-auth-form-wrapper .button-primary { width: 100%; }
-    .mobooking-auth-form-wrapper p { margin-bottom: 1rem; }
-    .mobooking-auth-form-wrapper p:last-of-type { margin-bottom: 0; } /* For the links below the form */
-    #mobooking-login-message.error { color: #dc2626; background-color: #fee2e2; border: 1px solid #ef4444; padding: 10px; border-radius: 4px; margin-bottom: 1rem; }
-    #mobooking-login-message.success { color: #166534; background-color: #dcfce7; border: 1px solid #22c55e; padding: 10px; border-radius: 4px; margin-bottom: 1rem; }
-</style>
-<?php
-get_footer();
+get_footer(); // This will be hidden by CSS in auth-pages.css for these templates

--- a/page-register.php
+++ b/page-register.php
@@ -10,7 +10,7 @@ if ( is_user_logged_in() ) {
     exit;
 }
 
-get_header();
+get_header(); // This will be hidden by CSS in auth-pages.css for these templates
 
 $invitation_token = null;
 $invitation_data = null;
@@ -52,136 +52,121 @@ if ( isset( $_GET['invitation_token'] ) ) {
         $invitation_token = null;
     }
 }
-
 ?>
-<main id="main" class="site-main">
-    <div id="mobooking-register-form-container" class="mobooking-auth-form-wrapper">
-        <style>
-            .mobooking-auth-form-wrapper { max-width: 500px; margin: 2rem auto; padding: 2rem; background: #fff; border: 1px solid #e2e8f0; border-radius: 0.5rem; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06); }
-            /* .mobooking-register-step { animation: fadeIn 0.5s; }
-            @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } } */
-            .mobooking-register-step {
-                opacity: 0;
-                transform: translateY(10px);
-                transition: opacity 0.3s ease-out, transform 0.3s ease-out;
-                display: none;
-                visibility: hidden;
-            }
-            .mobooking-register-step.active {
-                opacity: 1;
-                transform: translateY(0);
-                display: block;
-                visibility: visible;
-            }
-            .mobooking-register-step h3 { margin-top: 0; margin-bottom: 1.5rem; font-size: 1.25rem; border-bottom: 1px solid #e2e8f0; padding-bottom: 0.75rem; }
-            .form-navigation { margin-top: 1.5rem; display: flex; justify-content: space-between; }
-            .form-navigation .button { min-width: 100px; }
-            .mobooking-progress-step { padding: 8px 12px; border: 1px solid #e2e8f0; border-radius: 4px; background-color: #f8fafc; color: #64748b; transition: all 0.3s ease; }
-            .mobooking-progress-step.active { background-color: #3b82f6; color: white; border-color: #3b82f6; font-weight: 500; }
-            #mobooking-register-message.error { color: #dc2626; background-color: #fee2e2; border: 1px solid #ef4444; padding: 10px; border-radius: 4px;}
-            #mobooking-register-message.success { color: #166534; background-color: #dcfce7; border: 1px solid #22c55e; padding: 10px; border-radius: 4px;}
-        </style>
-        <h2><?php
-            if ($is_invitation) {
-                esc_html_e( 'Complete Your Worker Registration', 'mobooking' );
-            } else {
-                esc_html_e( 'Register Your Business', 'mobooking' );
-            }
-        ?></h2>
 
-        <?php if ( ! empty( $invitation_error ) ) : ?>
-            <div class="mobooking-message error"><p><?php echo $invitation_error; ?></p></div>
-        <?php endif; ?>
-
-        <?php if ( ! empty( $invitation_message ) ) : ?>
-            <div class="mobooking-message success"><p><?php echo $invitation_message; ?></p></div>
-        <?php endif; ?>
-
-        <div id="mobooking-progress-bar" style="display: flex; justify-content: space-between; margin-bottom: 20px;">
-            <div class="mobooking-progress-step active" data-step="1"><?php esc_html_e('Account', 'mobooking'); ?></div>
-            <div class="mobooking-progress-step" data-step="2"><?php esc_html_e('Personal', 'mobooking'); ?></div>
-            <div class="mobooking-progress-step" data-step="3"><?php esc_html_e('Business', 'mobooking'); ?></div>
+<div class="mobooking-auth-page-container">
+    <div class="mobooking-auth-grid">
+        <div class="mobooking-auth-image-column">
+            <div class="placeholder-content">
+                <h1><?php bloginfo('name'); ?></h1>
+                <p><?php esc_html_e('Join us and streamline your business operations.', 'mobooking'); ?></p>
+            </div>
         </div>
+        <div class="mobooking-auth-form-column">
+            <main id="main" class="site-main">
+                <div id="mobooking-register-form-container" class="mobooking-auth-form-wrapper">
+                    <?php /* Inline styles previously here are now removed and handled by auth-pages.css */ ?>
+                    <h2><?php
+                        if ($is_invitation) {
+                            esc_html_e( 'Complete Your Worker Registration', 'mobooking' );
+                        } else {
+                            esc_html_e( 'Register Your Business', 'mobooking' );
+                        }
+                    ?></h2>
 
-        <form id="mobooking-register-form">
-            <?php if ( $is_invitation && $invitation_token ) : ?>
-                <input type="hidden" name="inviter_id" id="mobooking-inviter-id" value="<?php echo esc_attr( $inviter_id ); ?>" />
-                <input type="hidden" name="assigned_role" id="mobooking-assigned-role" value="<?php echo esc_attr( $assigned_role ); ?>" />
-                <input type="hidden" name="invitation_token" id="mobooking-invitation-token" value="<?php echo esc_attr( $invitation_token ); ?>" />
-            <?php endif; ?>
+                    <?php if ( ! empty( $invitation_error ) ) : ?>
+                        <div class="mobooking-message error"><p><?php echo $invitation_error; ?></p></div>
+                    <?php endif; ?>
 
-            <!-- Step 1: Account Setup -->
-            <div id="mobooking-register-step-1" class="mobooking-register-step active">
-                <h3><?php esc_html_e( 'Step 1: Account Setup', 'mobooking' ); ?></h3>
-                <p class="register-email">
-                    <label for="mobooking-user-email"><?php esc_html_e( 'Email Address', 'mobooking' ); ?></label>
-                    <input type="email" name="email" id="mobooking-user-email" class="input" value="<?php echo esc_attr( $worker_email ); ?>" required <?php if ( $is_invitation && !empty($worker_email) ) echo 'readonly'; ?> />
-                </p>
-                <p class="register-password">
-                    <label for="mobooking-user-pass"><?php esc_html_e( 'Password (min. 8 characters)', 'mobooking' ); ?></label>
-                    <input type="password" name="password" id="mobooking-user-pass" class="input" value="" required />
-                </p>
-                <p class="register-password-confirm">
-                    <label for="mobooking-user-pass-confirm"><?php esc_html_e( 'Confirm Password', 'mobooking' ); ?></label>
-                    <input type="password" name="password_confirm" id="mobooking-user-pass-confirm" class="input" value="" required />
-                </p>
-                <div class="form-navigation">
-                    <button type="button" id="mobooking-step-1-next" class="button button-primary"><?php esc_html_e( 'Next', 'mobooking' ); ?></button>
+                    <?php if ( ! empty( $invitation_message ) ) : ?>
+                        <div class="mobooking-message success"><p><?php echo $invitation_message; ?></p></div>
+                    <?php endif; ?>
+
+                    <div id="mobooking-progress-bar">
+                        <div class="mobooking-progress-step active" data-step="1"><?php esc_html_e('Personal Info', 'mobooking'); ?></div>
+                        <div class="mobooking-progress-step" data-step="2"><?php esc_html_e('Business Info', 'mobooking'); ?></div>
+                        <div class="mobooking-progress-step" data-step="3"><?php esc_html_e('Confirm', 'mobooking'); ?></div>
+                    </div>
+
+                    <form id="mobooking-register-form">
+                        <?php if ( $is_invitation && $invitation_token ) : ?>
+                            <input type="hidden" name="inviter_id" id="mobooking-inviter-id" value="<?php echo esc_attr( $inviter_id ); ?>" />
+                            <input type="hidden" name="assigned_role" id="mobooking-assigned-role" value="<?php echo esc_attr( $assigned_role ); ?>" />
+                            <input type="hidden" name="invitation_token" id="mobooking-invitation-token" value="<?php echo esc_attr( $invitation_token ); ?>" />
+                        <?php endif; ?>
+
+                        <!-- Step 1: Personal Information -->
+                        <div id="mobooking-register-step-1" class="mobooking-register-step active">
+                            <h3><?php esc_html_e( 'Step 1: Personal Information', 'mobooking' ); ?></h3>
+                            <p class="register-name">
+                                <label for="mobooking-user-name"><?php esc_html_e( 'Full Name', 'mobooking' ); ?></label>
+                                <input type="text" name="name" id="mobooking-user-name" class="input" value="" required />
+                            </p>
+                            <p class="register-email">
+                                <label for="mobooking-user-email"><?php esc_html_e( 'Email Address', 'mobooking' ); ?></label>
+                                <input type="email" name="email" id="mobooking-user-email" class="input" value="<?php echo esc_attr( $worker_email ); ?>" required <?php if ( $is_invitation && !empty($worker_email) ) echo 'readonly'; ?> />
+                            </p>
+                            <p class="register-password">
+                                <label for="mobooking-user-pass"><?php esc_html_e( 'Password (min. 8 characters)', 'mobooking' ); ?></label>
+                                <input type="password" name="password" id="mobooking-user-pass" class="input" value="" required />
+                            </p>
+                            <p class="register-password-confirm">
+                                <label for="mobooking-user-pass-confirm"><?php esc_html_e( 'Confirm Password', 'mobooking' ); ?></label>
+                                <input type="password" name="password_confirm" id="mobooking-user-pass-confirm" class="input" value="" required />
+                            </p>
+                            <div class="form-navigation">
+                                <button type="button" id="mobooking-step-1-next" class="button button-primary"><?php esc_html_e( 'Next', 'mobooking' ); ?></button>
+                            </div>
+                        </div>
+
+                        <!-- Step 2: Business Information -->
+                        <div id="mobooking-register-step-2" class="mobooking-register-step" style="display:none;">
+                            <h3><?php esc_html_e( 'Step 2: Business Information', 'mobooking' ); ?></h3>
+                             <?php if ( !$is_invitation ): // Don't show company name for invited workers ?>
+                            <p class="register-company-name">
+                                <label for="mobooking-company-name"><?php esc_html_e( 'Company Name', 'mobooking' ); ?></label>
+                                <input type="text" name="company_name" id="mobooking-company-name" class="input" value="" required />
+                                <small><?php esc_html_e( 'This will be used to generate your unique business URL (slug).', 'mobooking' ); ?></small>
+                            </p>
+                            <?php else: ?>
+                                <p><?php esc_html_e('You are being invited as a worker. No company information is needed from you at this step.', 'mobooking'); ?></p>
+                                <input type="hidden" name="company_name" id="mobooking-company-name" value="" /> <!-- Send empty for workers -->
+                            <?php endif; ?>
+                            <div class="form-navigation">
+                                <button type="button" id="mobooking-step-2-prev" class="button"><?php esc_html_e( 'Previous', 'mobooking' ); ?></button>
+                                <button type="button" id="mobooking-step-2-next" class="button button-primary"><?php esc_html_e( 'Next', 'mobooking' ); ?></button>
+                            </div>
+                        </div>
+
+                        <!-- Step 3: Confirmation -->
+                        <div id="mobooking-register-step-3" class="mobooking-register-step" style="display:none;">
+                            <h3><?php esc_html_e( 'Step 3: Confirm Your Details', 'mobooking' ); ?></h3>
+                            <div id="mobooking-confirmation-details">
+                                <p><strong><?php esc_html_e('Name:', 'mobooking'); ?></strong> <span id="confirm-name"></span></p>
+                                <p><strong><?php esc_html_e('Email:', 'mobooking'); ?></strong> <span id="confirm-email"></span></p>
+                                <?php if ( !$is_invitation ): ?>
+                                <p><strong><?php esc_html_e('Company Name:', 'mobooking'); ?></strong> <span id="confirm-company-name"></span></p>
+                                <?php endif; ?>
+                            </div>
+                            <div class="form-navigation">
+                                <button type="button" id="mobooking-step-3-prev" class="button"><?php esc_html_e( 'Previous', 'mobooking' ); ?></button>
+                                <input type="submit" name="wp-submit" id="mobooking-wp-submit-register" class="button button-primary" value="<?php esc_attr_e( 'Confirm & Register', 'mobooking' ); ?>" />
+                            </div>
+                        </div>
+
+                        <div id="mobooking-register-message" style="display:none; margin-top: 15px;"></div>
+                    </form>
+                    <div class="mobooking-auth-links">
+                        <p>
+                            <?php esc_html_e( 'Already have an account?', 'mobooking' ); ?>
+                            <a href="<?php echo esc_url( home_url( '/login/' ) ); ?>"><?php esc_html_e( 'Log In', 'mobooking' ); ?></a>
+                        </p>
+                    </div>
                 </div>
-            </div>
-
-            <!-- Step 2: Personal Details -->
-            <div id="mobooking-register-step-2" class="mobooking-register-step" style="display:none;">
-                <h3><?php esc_html_e( 'Step 2: Personal Details', 'mobooking' ); ?></h3>
-                <p class="register-first-name">
-                    <label for="mobooking-first-name"><?php esc_html_e( 'First Name', 'mobooking' ); ?></label>
-                    <input type="text" name="first_name" id="mobooking-first-name" class="input" value="" required />
-                </p>
-                <p class="register-last-name">
-                    <label for="mobooking-last-name"><?php esc_html_e( 'Last Name', 'mobooking' ); ?></label>
-                    <input type="text" name="last_name" id="mobooking-last-name" class="input" value="" required />
-                </p>
-                <div class="form-navigation">
-                    <button type="button" id="mobooking-step-2-prev" class="button"><?php esc_html_e( 'Previous', 'mobooking' ); ?></button>
-                    <button type="button" id="mobooking-step-2-next" class="button button-primary"><?php esc_html_e( 'Next', 'mobooking' ); ?></button>
-                </div>
-            </div>
-
-            <!-- Step 3: Business Information -->
-            <div id="mobooking-register-step-3" class="mobooking-register-step" style="display:none;">
-                <h3><?php esc_html_e( 'Step 3: Business Information', 'mobooking' ); ?></h3>
-                <p class="register-company-name">
-                    <label for="mobooking-company-name"><?php esc_html_e( 'Company Name', 'mobooking' ); ?></label>
-                    <input type="text" name="company_name" id="mobooking-company-name" class="input" value="" required />
-                    <small><?php esc_html_e( 'This will be used to generate your unique business URL (slug).', 'mobooking' ); ?></small>
-                </p>
-                <div class="form-navigation">
-                    <button type="button" id="mobooking-step-3-prev" class="button"><?php esc_html_e( 'Previous', 'mobooking' ); ?></button>
-                    <input type="submit" name="wp-submit" id="mobooking-wp-submit-register" class="button button-primary" value="<?php esc_attr_e( 'Register', 'mobooking' ); ?>" />
-                </div>
-            </div>
-
-            <div id="mobooking-register-message" style="display:none; margin-top: 15px;"></div>
-        </form>
-        <p style="margin-top: 20px;">
-            <?php esc_html_e( 'Already have an account?', 'mobooking' ); ?>
-            <a href="<?php echo esc_url( home_url( '/login/' ) ); ?>"><?php esc_html_e( 'Log In', 'mobooking' ); ?></a>
-        </p>
+            </main>
+        </div>
     </div>
-</main>
-
-<style>
-    .mobooking-auth-form-wrapper { max-width: 500px; margin: 2rem auto; padding: 2rem; background: #fff; border: 1px solid #e2e8f0; border-radius: 0.5rem; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06); }
-    .mobooking-register-step { animation: fadeIn 0.5s; }
-    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
-    .mobooking-register-step h3 { margin-top: 0; margin-bottom: 1.5rem; font-size: 1.25rem; border-bottom: 1px solid #e2e8f0; padding-bottom: 0.75rem; }
-    .form-navigation { margin-top: 1.5rem; display: flex; justify-content: space-between; }
-    .form-navigation .button { min-width: 100px; }
-    .mobooking-progress-step { padding: 8px 12px; border: 1px solid #e2e8f0; border-radius: 4px; background-color: #f8fafc; color: #64748b; transition: all 0.3s ease; }
-    .mobooking-progress-step.active { background-color: #3b82f6; color: white; border-color: #3b82f6; font-weight: 500; }
-    #mobooking-register-message.error { color: #dc2626; background-color: #fee2e2; border: 1px solid #ef4444; padding: 10px; border-radius: 4px;}
-    #mobooking-register-message.success { color: #166534; background-color: #dcfce7; border: 1px solid #22c55e; padding: 10px; border-radius: 4px;}
-</style>
+</div>
 
 <?php
-get_footer();
+get_footer(); // This will be hidden by CSS


### PR DESCRIPTION
- Fixes AJAX 500 error in registration by changing BookingFormRouter::get_user_id_by_slug to public static.
- Restructures registration into 3 steps:
  1. Personal Info: Full Name, Email, Password.
  2. Business Info: Company Name (for slug generation).
  3. Confirmation: Review details.
- Updates page-register.php, assets/js/auth.js, and classes/Auth.php to support the new structure and 'Full Name' field processing.
- Implements a 2-column grid layout for login and registration pages using assets/css/auth-pages.css.
- Applies initial shadcn/ui inspired styling to auth pages, inputs, and buttons.
- Implements real-time client-side validation for registration form fields.
- Updates links on front-page.php to point to the new /register and /login pages.
- Updates PHPUnit tests for the registration logic to reflect the 'Full Name' field and new step structure.