### PR TITLE
fix: Resolve JS errors and revert to First/Last Name in registration

### DIFF
--- a/classes/Auth.php
+++ b/classes/Auth.php
@@ -420,9 +420,10 @@ class Auth {
         check_ajax_referer( self::REGISTER_NONCE_ACTION, 'nonce' );
 
         // Step 1 Data: Personal Information
-        $name     = isset($_POST['name']) ? sanitize_text_field(trim($_POST['name'])) : '';
-        $email    = isset($_POST['email']) ? sanitize_email( $_POST['email'] ) : '';
-        $password = isset($_POST['password']) ? $_POST['password'] : '';
+        $first_name = isset($_POST['first_name']) ? sanitize_text_field(trim($_POST['first_name'])) : '';
+        $last_name  = isset($_POST['last_name']) ? sanitize_text_field(trim($_POST['last_name'])) : '';
+        $email      = isset($_POST['email']) ? sanitize_email( $_POST['email'] ) : '';
+        $password   = isset($_POST['password']) ? $_POST['password'] : '';
         $password_confirm = isset($_POST['password_confirm']) ? $_POST['password_confirm'] : '';
 
         // Step 2 Data: Business Information
@@ -430,8 +431,11 @@ class Auth {
 
         // --- Server-Side Validation ---
         // Personal Information
-        if ( empty( $name ) ) {
-            wp_send_json_error( array( 'message' => __( 'Full name is required.', 'mobooking' ) ) );
+        if ( empty( $first_name ) ) {
+            wp_send_json_error( array( 'message' => __( 'First name is required.', 'mobooking' ) ) );
+        }
+        if ( empty( $last_name ) ) {
+            wp_send_json_error( array( 'message' => __( 'Last name is required.', 'mobooking' ) ) );
         }
         if ( empty( $email ) || ! is_email( $email ) ) {
             wp_send_json_error( array( 'message' => __( 'A valid email address is required.', 'mobooking' ) ) );
@@ -463,16 +467,19 @@ class Auth {
         } else {
             $user = new \WP_User( $user_id );
 
-            // Process and save name
-            $name_parts = explode( ' ', $name, 2 );
-            $first_name = $name_parts[0];
-            $last_name  = isset( $name_parts[1] ) ? $name_parts[1] : '';
+            // Update user with first name, last name, and display name
+            // For display name, we'll concatenate first and last if both exist, otherwise use email prefix.
+            $display_name = trim($first_name . ' ' . $last_name);
+            if(empty($display_name)) {
+                $email_parts = explode('@', $email);
+                $display_name = $email_parts[0];
+            }
 
             wp_update_user( array(
                 'ID' => $user_id,
                 'first_name' => $first_name,
                 'last_name' => $last_name,
-                'display_name' => $name // Use full name for display name
+                'display_name' => $display_name
             ) );
 
             // Check if this is a worker registration (invitation flow)

--- a/page-register.php
+++ b/page-register.php
@@ -98,9 +98,13 @@ if ( isset( $_GET['invitation_token'] ) ) {
                         <!-- Step 1: Personal Information -->
                         <div id="mobooking-register-step-1" class="mobooking-register-step active">
                             <h3><?php esc_html_e( 'Step 1: Personal Information', 'mobooking' ); ?></h3>
-                            <p class="register-name">
-                                <label for="mobooking-user-name"><?php esc_html_e( 'Full Name', 'mobooking' ); ?></label>
-                                <input type="text" name="name" id="mobooking-user-name" class="input" value="" required />
+                            <p class="register-first-name">
+                                <label for="mobooking-first-name"><?php esc_html_e( 'First Name', 'mobooking' ); ?></label>
+                                <input type="text" name="first_name" id="mobooking-first-name" class="input" value="" required />
+                            </p>
+                            <p class="register-last-name">
+                                <label for="mobooking-last-name"><?php esc_html_e( 'Last Name', 'mobooking' ); ?></label>
+                                <input type="text" name="last_name" id="mobooking-last-name" class="input" value="" required />
                             </p>
                             <p class="register-email">
                                 <label for="mobooking-user-email"><?php esc_html_e( 'Email Address', 'mobooking' ); ?></label>
@@ -125,7 +129,7 @@ if ( isset( $_GET['invitation_token'] ) ) {
                              <?php if ( !$is_invitation ): // Don't show company name for invited workers ?>
                             <p class="register-company-name">
                                 <label for="mobooking-company-name"><?php esc_html_e( 'Company Name', 'mobooking' ); ?></label>
-                                <input type="text" name="company_name" id="mobooking-company-name" class="input" value="" required />
+                    <input type="text" name="company_name" id="mobooking-company-name" class="input" value="" /> <!-- Removed required -->
                                 <small><?php esc_html_e( 'This will be used to generate your unique business URL (slug).', 'mobooking' ); ?></small>
                             </p>
                             <?php else: ?>
@@ -142,7 +146,8 @@ if ( isset( $_GET['invitation_token'] ) ) {
                         <div id="mobooking-register-step-3" class="mobooking-register-step" style="display:none;">
                             <h3><?php esc_html_e( 'Step 3: Confirm Your Details', 'mobooking' ); ?></h3>
                             <div id="mobooking-confirmation-details">
-                                <p><strong><?php esc_html_e('Name:', 'mobooking'); ?></strong> <span id="confirm-name"></span></p>
+                                <p><strong><?php esc_html_e('First Name:', 'mobooking'); ?></strong> <span id="confirm-first-name"></span></p>
+                                <p><strong><?php esc_html_e('Last Name:', 'mobooking'); ?></strong> <span id="confirm-last-name"></span></p>
                                 <p><strong><?php esc_html_e('Email:', 'mobooking'); ?></strong> <span id="confirm-email"></span></p>
                                 <?php if ( !$is_invitation ): ?>
                                 <p><strong><?php esc_html_e('Company Name:', 'mobooking'); ?></strong> <span id="confirm-company-name"></span></p>

--- a/tests/test-auth.php
+++ b/tests/test-auth.php
@@ -240,7 +240,8 @@ class Test_MoBooking_Auth extends WP_UnitTestCase {
             'email'            => 'newowner@example.com',
             'password'         => 'password123',
             'password_confirm' => 'password123',
-            'name'             => 'Test Owner FullName', // Changed to 'name'
+            'first_name'       => 'Test',
+            'last_name'        => 'Owner',
             'company_name'     => 'Test Company Inc.',
         ];
 
@@ -252,9 +253,9 @@ class Test_MoBooking_Auth extends WP_UnitTestCase {
 
         $user = get_user_by('email', 'newowner@example.com');
         $this->assertInstanceOf(WP_User::class, $user);
-        $this->assertEquals('Test', $user->first_name); // Based on splitting logic "Test Owner FullName" -> "Test"
-        $this->assertEquals('Owner FullName', $user->last_name); // and "Owner FullName"
-        $this->assertEquals('Test Owner FullName', $user->display_name);
+        $this->assertEquals('Test', $user->first_name);
+        $this->assertEquals('Owner', $user->last_name);
+        $this->assertEquals('Test Owner', $user->display_name); // Default display name logic
         $this->assertEquals('Test Company Inc.', get_user_meta($user->ID, 'mobooking_company_name', true));
         $this->assertTrue(in_array(Auth::ROLE_BUSINESS_OWNER, $user->roles));
 
@@ -282,7 +283,8 @@ class Test_MoBooking_Auth extends WP_UnitTestCase {
             'email'            => 'owner1@example.com',
             'password'         => 'password123',
             'password_confirm' => 'password123',
-            'name'             => 'Owner One',
+            'first_name'       => 'Owner',
+            'last_name'        => 'One',
             'company_name'     => 'Unique Company',
         ];
         $this->call_ajax_handler([$this->auth_instance, 'handle_ajax_registration']);
@@ -297,7 +299,8 @@ class Test_MoBooking_Auth extends WP_UnitTestCase {
             'email'            => 'owner2@example.com',
             'password'         => 'password123',
             'password_confirm' => 'password123',
-            'name'             => 'Owner Two',
+            'first_name'       => 'Owner',
+            'last_name'        => 'Two',
             'company_name'     => 'Unique Company',
         ];
         $this->call_ajax_handler([$this->auth_instance, 'handle_ajax_registration']);
@@ -311,7 +314,8 @@ class Test_MoBooking_Auth extends WP_UnitTestCase {
             'email'            => 'owner3@example.com',
             'password'         => 'password123',
             'password_confirm' => 'password123',
-            'name'             => 'Owner Three',
+            'first_name'       => 'Owner',
+            'last_name'        => 'Three',
             'company_name'     => 'Unique Company 2', // sanitize_title makes this 'unique-company-2'
         ];
         $this->call_ajax_handler([$this->auth_instance, 'handle_ajax_registration']);
@@ -338,7 +342,8 @@ class Test_MoBooking_Auth extends WP_UnitTestCase {
      */
     public function test_handle_ajax_registration_missing_fields() {
         $test_cases = [
-            ['name', 'Full name is required.'],
+            ['first_name', 'First name is required.'],
+            ['last_name', 'Last name is required.'],
             ['email', 'A valid email address is required.'],
             ['password', 'Please enter a password.'],
             ['password_confirm', 'Passwords do not match.'],
@@ -347,7 +352,8 @@ class Test_MoBooking_Auth extends WP_UnitTestCase {
 
         $base_data = [
             'nonce'            => wp_create_nonce(Auth::REGISTER_NONCE_ACTION),
-            'name'             => 'Test User FullName',
+            'first_name'       => 'Test',
+            'last_name'        => 'User',
             'email'            => 'missingfields@example.com',
             'password'         => 'password123',
             'password_confirm' => 'password123',
@@ -394,8 +400,9 @@ class Test_MoBooking_Auth extends WP_UnitTestCase {
             'email'             => 'invitedworker@example.com',
             'password'          => 'password123',
             'password_confirm'  => 'password123',
-            'name'              => 'Invited Worker FullName', // Changed to 'name'
-            // company_name is not required and should be empty or not sent for invited worker
+            'first_name'        => 'Invited',
+            'last_name'         => 'Worker',
+            // company_name is not required for invited worker
             'inviter_id'        => $this->business_owner_id,
             'role_to_assign'    => Auth::ROLE_WORKER_STAFF,
             'invitation_token'  => $token,
@@ -408,9 +415,9 @@ class Test_MoBooking_Auth extends WP_UnitTestCase {
 
         $user = get_user_by('email', 'invitedworker@example.com');
         $this->assertInstanceOf(WP_User::class, $user);
-        $this->assertEquals('Invited', $user->first_name); // Based on splitting "Invited Worker FullName"
-        $this->assertEquals('Worker FullName', $user->last_name);
-        $this->assertEquals('Invited Worker FullName', $user->display_name);
+        $this->assertEquals('Invited', $user->first_name);
+        $this->assertEquals('Worker', $user->last_name);
+        $this->assertEquals('Invited Worker', $user->display_name); // Default display name logic
         $this->assertTrue(in_array(Auth::ROLE_WORKER_STAFF, $user->roles));
         $this->assertEquals($this->business_owner_id, get_user_meta($user->ID, Auth::META_KEY_OWNER_ID, true));
 


### PR DESCRIPTION
- Fixes JavaScript ReferenceErrors by moving validation functions (`validateFirstNameField`, `validateLastNameField`, etc.) to the correct outer scope in `assets/js/auth.js`.
- Reverts the registration form and processing logic to use separate 'First Name' and 'Last Name' fields instead of 'Full Name'.
  - Updates `page-register.php` HTML for first/last name inputs and confirmation display.
  - Updates `assets/js/auth.js` for data collection, validation, and real-time listeners for first/last name.
  - Updates `classes/Auth.php` to process `first_name` and `last_name` from `$_POST`.
  - Updates PHPUnit tests in `tests/test-auth.php` to reflect the use of `first_name` and `last_name`.
- Removes the `required` HTML attribute from the 'Company Name' field in `page-register.php` to prevent 'not focusable' errors when the field is hidden during worker invitation flow. Validation is handled by JS and PHP.