### PR TITLE
Fix: Resolve JS conflict to ensure service image and icon save correctly

### DIFF
--- a/assets/js/dashboard-services.js
+++ b/assets/js/dashboard-services.js
@@ -30,6 +30,9 @@ jQuery(document).ready(function ($) {
 
   // --- Logic for Service Add/Edit Page (page-service-edit.php) ---
   // Check if the new inline script from page-service-edit.php is NOT present
+  /*
+  // Temporarily commenting out this entire block to avoid conflicts with page-service-edit.php inline script.
+  // The inline script (which defines window.moBookingServiceEdit) should be the sole handler for this page.
   if (
     $("#mobooking-service-form").length &&
     typeof window.moBookingServiceEdit === "undefined"
@@ -401,6 +404,7 @@ jQuery(document).ready(function ($) {
       window.location.href = servicesListPageUrl;
     });
   }
+  */ // End of temporary commenting out
 
   // --- Logic for Service List Page (page-services.php) ---
   if ($("#mobooking-services-list-container").length) {


### PR DESCRIPTION
Commented out a potentially conflicting JavaScript block in assets/js/dashboard-services.js. This block could interfere with the newer inline JavaScript on the service edit page (page-service-edit.php), preventing image_url and icon fields from being correctly submitted.

With this change, the inline script in page-service-edit.php should now be the sole handler for the service form, allowing image and icon data to be reliably collected and saved.