### PR TITLE
Refactor: Enhance booking form settings validation for Step 1 disable…

### DIFF
--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -316,6 +316,9 @@ private function validate_and_sanitize_booking_form_settings($settings_data) {
             'type' => 'number',
             'min' => 0,
             'max' => 50
+        ],
+        'bf_enable_location_check' => [ // Added for explicit boolean handling
+            'type' => 'boolean'
         ]
     ];
 


### PR DESCRIPTION
… option

Verified existing functionality for disabling Step 1 ('Check Service Availability') of the public booking form via the 'bf_enable_location_check' setting.

Enhanced `Settings.php` by adding `bf_enable_location_check` to the explicit validation rules to ensure robust boolean handling during sanitization.

Confirmed that services and their corresponding options load correctly in both scenarios (Step 1 enabled or disabled). No issues found in the data flow or rendering logic for services and various option types.