### PR TITLE
Fix: Ensure Step 1 of booking form correctly hides based on admin set…

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -178,6 +178,10 @@ function mobooking_scripts() {
             'currency_code' => $public_form_currency_code,
             'site_url' => site_url(),
             'i18n' => $i18n_strings,
+            // ADDED: Pass booking form settings to JavaScript
+            'settings' => isset($GLOBALS['mobooking_settings_manager']) && $effective_tenant_id_for_public_form
+                          ? $GLOBALS['mobooking_settings_manager']->get_booking_form_settings($effective_tenant_id_for_public_form)
+                          : \MoBooking\Classes\Settings::get_all_default_settings(), // Fallback to plugin defaults if manager/tenant ID invalid
         ]);
     }
 


### PR DESCRIPTION
…ting

Resolved an issue where disabling 'Enable Location Check Step (Step 1)' did not hide Step 1 on the public booking form.

The root cause was that the booking form settings were not being passed from PHP to the `assets/js/booking-form.js` script.

This commit updates `functions.php` to correctly include the tenant-specific booking form settings in the `wp_localize_script` call for the public booking form. This allows the JavaScript to accurately determine the value of `bf_enable_location_check` and behave as intended.

Removed temporary debugging console.log from `booking-form.js`.