### PR TITLE
Attempt to fix booking form rendering and JS errors

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -227,7 +227,23 @@ if ( is_page_template('templates/booking-form-public.php') || $page_type_for_scr
         'currency_code' => $public_form_currency_code,
         'site_url' => site_url(),
         'i18n' => $i18n_strings,
-        'settings' => $tenant_settings,
+        'settings' => [
+            // Ensure specific string settings are JS-escaped
+            'bf_header_text' => isset($tenant_settings['bf_header_text']) ? esc_js($tenant_settings['bf_header_text']) : '',
+            'bf_show_pricing' => $tenant_settings['bf_show_pricing'] ?? '1',
+            'bf_allow_discount_codes' => $tenant_settings['bf_allow_discount_codes'] ?? '1',
+            'bf_theme_color' => $tenant_settings['bf_theme_color'] ?? '#1abc9c',
+            // For bf_custom_css, esc_js might be too aggressive if it contains valid CSS quotes.
+            // However, if it's breaking JS, it needs care. wp_json_encode (used by wp_localize_script) should handle it.
+            // If bf_custom_css is truly the issue, it implies very unusual characters.
+            'bf_custom_css' => $tenant_settings['bf_custom_css'] ?? '',
+            'bf_form_enabled' => $tenant_settings['bf_form_enabled'] ?? '1',
+            'bf_maintenance_message' => isset($tenant_settings['bf_maintenance_message']) ? esc_js($tenant_settings['bf_maintenance_message']) : '',
+            'bf_enable_location_check' => $tenant_settings['bf_enable_location_check'] ?? '1',
+            // Add any other settings, ensuring strings that might contain problematic characters are escaped
+            // For example, if there were other free-text fields:
+            // 'another_free_text_setting' => isset($tenant_settings['another_free_text_setting']) ? esc_js($tenant_settings['another_free_text_setting']) : '',
+        ],
         // Add debug info
         'debug_info' => [
             'page_type' => $page_type_for_scripts,

--- a/templates/booking-form-public.php
+++ b/templates/booking-form-public.php
@@ -1434,11 +1434,11 @@ document.addEventListener('DOMContentLoaded', function() {
                                 <i class="fas fa-home"></i>
                             </div>
                             <div class="mobooking-bf__service-info">
-                                <h4 class="mobooking-bf__service-name">House Cleaning</h4>
+                                <h4 class="mobooking-bf__service-name">House Cleaning (Simulated)</h4>
                                 <p class="mobooking-bf__service-price">$120.00</p>
                             </div>
                         </div>
-                        <p class="mobooking-bf__service-description">Complete house cleaning service including all rooms, kitchen, and bathrooms.</p>
+                        <p class="mobooking-bf__service-description">Simulated description.</p>
                         <div class="mobooking-bf__service-meta">
                             <span class="mobooking-bf__service-duration">
                                 <i class="fas fa-clock"></i>


### PR DESCRIPTION
- Replaced bfRenderTemplate with a more robust version to handle Underscore.js-style templates.
- Applied esc_js to specific string settings in wp_localize_script.
- Simplified a hardcoded HTML string in an inline script for diagnostics.

Further debugging is likely needed as the main SyntaxError may persist.