### PR TITLE
Fix: Define getStepName as standalone function in booking form JS

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -15,6 +15,11 @@ jQuery(document).ready(function($) {
     let locationVerified = !(MOB_PARAMS.settings && MOB_PARAMS.settings.bf_enable_location_check === '1');
 
     // --- UTILITY FUNCTIONS ---
+    function getStepName(stepNumber) { // Added missing function
+        const names = ["", "location", "services", "options", "details", "review", "success"];
+        return names[stepNumber] || "unknown";
+    }
+
     function escapeHtml(text) {
         if (typeof text !== 'string') return '';
         const div = document.createElement('div');


### PR DESCRIPTION
Resolved a ReferenceError where getStepName was not defined. The function was previously a method of the MoBookingForm object and was not correctly hoisted during the refactor to a jQuery-based approach.

It is now defined as a standalone utility function.