### PR TITLE
Debug: Add logging for SQM range objects in generateOptionHTML

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -392,8 +392,9 @@ jQuery(document).ready(function($) {
                          // Display ranges if helpful
                     if (sqmRanges.length > 0) {
                         optionFieldHtml += '<div class="mobooking-sqm-ranges-display">';
-                        sqmRanges.forEach(range => {
-                            optionFieldHtml += `<span>${range.from}-${range.to === '∞' ? '&infin;' : range.to} sqm: ${MOB_PARAMS.currency.symbol}${range.price}/sqm</span><br>`;
+                        sqmRanges.forEach((range, rIndex) => {
+                            console.log(`[MoBooking JS Debug] SQM Range ${rIndex}:`, range); // Log each range object
+                            optionFieldHtml += `<span>${escapeHtml(String(range.from))}-${range.to === '∞' ? '&infin;' : escapeHtml(String(range.to))} sqm: ${MOB_PARAMS.currency.symbol}${escapeHtml(String(range.price))}/sqm</span><br>`;
                         });
                         optionFieldHtml += '</div>';
                     }


### PR DESCRIPTION
Added console.log for each range object within the SQM option type's HTML generation loop. This will help inspect the structure of the range data (from, to, price properties) and diagnose the 'undefined-undefined sqm' display error.