### PR TITLE
FIX: Correct booking details URL to use front-end router

### DIFF
--- a/dashboard/page-bookings.php
+++ b/dashboard/page-bookings.php
@@ -117,7 +117,8 @@ if ($current_user_id) {
             $booking_date_formatted = date_i18n(get_option('date_format'), strtotime($booking['booking_date']));
             $booking_time_formatted = date_i18n(get_option('time_format'), strtotime($booking['booking_time'])); // Assuming booking_time is just time
 
-            $details_page_url = admin_url('admin.php?page=mobooking&action=view_booking&booking_id=' . $booking['booking_id']);
+            // Corrected URL to point to the front-end dashboard route
+            $details_page_url = home_url('/dashboard/bookings/?action=view_booking&booking_id=' . $booking['booking_id']);
 
             $initial_bookings_html .= '<tr data-booking-id="' . esc_attr($booking['booking_id']) . '">';
             $initial_bookings_html .= '<td data-colname="' . esc_attr__('Ref', 'mobooking') . '">' . esc_html($booking['booking_reference']) . '</td>';


### PR DESCRIPTION
- Changed the 'View Details' button URL on the bookings page from an admin_url to a home_url pointing to the /dashboard/bookings/ path.
- This allows the theme's BookingFormRouter to correctly handle the request and load the single booking details view via page-bookings.php including page-booking-single.php.
- Resolves the 'Sorry, you are not allowed to access this page.' error by avoiding incorrect wp-admin page access.