### PR TITLE
FIX: Resolve fatal error on single booking page from private property…

### DIFF
--- a/classes/Bookings.php
+++ b/classes/Bookings.php
@@ -1207,5 +1207,27 @@ foreach ($calculated_service_items as $service_item) {
         
         return empty($errors) ? true : $errors;
     }
+
+    /**
+     * Get the owner user_id for a given booking_id.
+     *
+     * @param int $booking_id The ID of the booking.
+     * @return int|null The user_id of the booking owner, or null if not found.
+     */
+    public function get_booking_owner_id(int $booking_id): ?int {
+        if (empty($booking_id)) {
+            return null;
+        }
+        $bookings_table = Database::get_table_name('bookings');
+        $owner_id = $this->wpdb->get_var($this->wpdb->prepare(
+            "SELECT user_id FROM $bookings_table WHERE booking_id = %d",
+            $booking_id
+        ));
+
+        if ($owner_id === null) { // Check for null explicitly, as 0 could be a valid (though unlikely) user_id if not for auto-increment.
+            return null;
+        }
+        return (int) $owner_id;
+    }
 }
 ?>

--- a/dashboard/page-booking-single.php
+++ b/dashboard/page-booking-single.php
@@ -17,20 +17,13 @@ $booking_id_to_fetch = $single_booking_id;
 $user_id_for_permission_check = $current_user_id; // The logged-in user
 
 // Determine the actual owner ID of the booking for fetching and broad permission.
-// The get_booking method in Bookings.php needs the owner's ID.
-$booking_owner_id_for_fetch = null;
-$booking_to_check_ownership = $bookings_manager->wpdb->get_row( // Direct DB check to find owner first
-    $bookings_manager->wpdb->prepare(
-        "SELECT user_id FROM " . MoBooking\Classes\Database::get_table_name('bookings') . " WHERE booking_id = %d",
-        $booking_id_to_fetch
-    )
-);
+$actual_booking_owner_id = $bookings_manager->get_booking_owner_id($booking_id_to_fetch);
+$booking_owner_id_for_fetch = null; // Will be set if $can_view is true
 
-if (!$booking_to_check_ownership) {
-    echo '<div class="notice notice-error"><p>' . esc_html__( 'Booking not found.', 'mobooking' ) . '</p></div>';
+if ($actual_booking_owner_id === null) { // Check if null, meaning booking not found by the new method
+    echo '<div class="notice notice-error"><p>' . esc_html__( 'Booking not found or owner could not be determined.', 'mobooking' ) . '</p></div>';
     return;
 }
-$actual_booking_owner_id = (int) $booking_to_check_ownership->user_id;
 
 // Permission Check: Can the current user view this booking?
 $can_view = false;


### PR DESCRIPTION
… access

- I've added a new public method `get_booking_owner_id(int $booking_id)` to the `Bookings` class. This will allow you to fetch the owner ID of a booking without needing to directly access the database from outside the class.
- I've also modified `dashboard/page-booking-single.php` to use this new method. This avoids attempting to access the private `$bookings_manager->wpdb` property.
- These changes resolve the fatal error "Cannot access private property MoBooking\Classes\Bookings::$wpdb" and ensure proper encapsulation is maintained.