### PR TITLE
I've resolved multiple issues on the single booking details page for …

### DIFF
--- a/classes/Bookings.php
+++ b/classes/Bookings.php
@@ -800,9 +800,10 @@ foreach ($calculated_service_items as $service_item) {
             return;
         }
 
-        $valid_statuses = ['pending', 'confirmed', 'in-progress', 'completed', 'cancelled'];
+        // Ensure all statuses from the dropdown are considered valid
+        $valid_statuses = ['pending', 'confirmed', 'in-progress', 'completed', 'cancelled', 'on-hold', 'processing'];
         if (!in_array($new_status, $valid_statuses)) {
-            wp_send_json_error(['message' => __('Invalid status.', 'mobooking')]);
+            wp_send_json_error(['message' => __('Invalid status selected.', 'mobooking')]); // Slightly clearer message
             return;
         }
 


### PR DESCRIPTION
…you.

- I corrected the 'Back to Bookings List' URL so it now points to the front-end dashboard.
- I fixed some display errors in the 'Services & Options Booked' section. Specifically, I made sure it can handle potential array values for service options to prevent an 'Array to string conversion' error, and I'm now using the correct 'price' key for option pricing, which resolves the 'Undefined array key price_impact' warning.
- I also fixed an issue with changing the booking status by updating the backend list of valid statuses in `Bookings::handle_update_booking_status_ajax` to include 'on-hold' and 'processing'.