### PR TITLE
FIX: Use localized ajax_url in single booking page JavaScript

### DIFF
--- a/dashboard/page-booking-single.php
+++ b/dashboard/page-booking-single.php
@@ -278,7 +278,7 @@ jQuery(document).ready(function($) {
         $button.prop('disabled', true);
 
         $.ajax({
-            url: ajaxurl, // WordPress AJAX URL
+            url: mobooking_dashboard_params.ajax_url, // Use localized ajax_url
             type: 'POST',
             data: {
                 action: 'mobooking_update_booking_status',


### PR DESCRIPTION
- I modified the inline JavaScript in `dashboard/page-booking-single.php` to use `mobooking_dashboard_params.ajax_url` instead of the global `ajaxurl` variable.
- This resolves the 'ReferenceError: ajaxurl is not defined' because `ajaxurl` is not automatically defined on front-end routed dashboard pages.
- The `mobooking_dashboard_params` object, which includes the correct `ajax_url`, is provided via `wp_localize_script`.