### PR TITLE
I plan to add a custom HTML email template for WordPress emails.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1782,6 +1782,85 @@ if ( ! function_exists( 'mobooking_ajax_get_dashboard_overview_data' ) ) {
             //     )
             // );
 
+
+// --- Custom Email Template Functions ---
+
+/**
+ * Set email content type to HTML.
+ */
+add_filter( 'wp_mail_content_type', function() {
+    return 'text/html';
+});
+
+/**
+ * Set a default email from name.
+ */
+add_filter( 'wp_mail_from_name', function( $original_email_from ) {
+    // You can customize this, e.g., get_bloginfo('name')
+    return get_bloginfo('name');
+});
+
+/**
+ * Set a default email from address.
+ * It's good practice to use an email address from your site's domain.
+ */
+add_filter( 'wp_mail_from', function( $original_email_address ) {
+    $domain = wp_parse_url(home_url(), PHP_URL_HOST);
+    if (strpos($domain, 'www.') === 0) {
+        $domain = substr($domain, 4);
+    }
+    $default_from_email = 'wordpress@' . $domain;
+    // Check if the original email address is the default WordPress one.
+    // If it is, replace it. Otherwise, keep the potentially custom one.
+    if ($original_email_address === 'wordpress@' . $domain || $original_email_address === 'wordpress@localhost') {
+        return $default_from_email;
+    }
+    return $original_email_address; // Keep if it was already customized
+});
+
+
+/**
+ * Wrap email content with custom HTML template.
+ */
+add_filter( 'wp_mail', function( $args ) {
+    $template_path = get_stylesheet_directory() . '/templates/email/default-email-template.php';
+
+    if ( file_exists( $template_path ) ) {
+        $email_template = file_get_contents( $template_path );
+
+        // Replace placeholders
+        // Header Content - Example: Site Logo and Name
+        $site_logo_url = function_exists('get_custom_logo') ? wp_get_attachment_image_url(get_theme_mod('custom_logo'), 'full') : '';
+        $header_content = '';
+        if ($site_logo_url) {
+            $header_content .= '<img src="' . esc_url($site_logo_url) . '" alt="' . esc_attr(get_bloginfo('name')) . '" style="max-height:50px; margin-bottom:10px;" class="site-logo" />';
+            $header_content .= '<h1 style="color:#ffffff; font-size:24px; margin:0; font-weight:normal;"><a href="' . esc_url(home_url()) . '" style="color:#ffffff; text-decoration:none;">' . esc_html(get_bloginfo('name')) . '</a></h1>';
+        } else {
+            $header_content .= '<h1 style="color:#ffffff; font-size:24px; margin:0; font-weight:normal;"><a href="' . esc_url(home_url()) . '" style="color:#ffffff; text-decoration:none;">' . esc_html(get_bloginfo('name')) . '</a></h1>';
+        }
+        $email_template = str_replace( '%%EMAIL_HEADER_CONTENT%%', $header_content, $email_template );
+
+        // Main Content
+        // Convert line breaks to <br> for HTML display if the content is plain text
+        $message_content = nl2br( $args['message'] );
+        $email_template = str_replace( '%%EMAIL_CONTENT%%', $message_content, $email_template );
+
+        // Footer Content - Example: Copyright and Site Link
+        $footer_content = '&copy; ' . date('Y') . ' <a href="' . esc_url(home_url('/')) . '" style="color:#0073aa;">' . esc_html(get_bloginfo('name')) . '</a>. ' . __('All rights reserved.', 'mobooking');
+        $email_template = str_replace( '%%EMAIL_FOOTER_CONTENT%%', $footer_content, $email_template );
+
+        // Blog name for title tag
+        $email_template = str_replace( '%%BLOG_NAME%%', esc_html(get_bloginfo('name')), $email_template );
+
+
+        $args['message'] = $email_template;
+    }
+
+    return $args;
+}, 10, 1 );
+
+// --- End Custom Email Template Functions ---
+
             wp_send_json_success(array(
                 'kpis' => $kpi_data
                 // 'chart_data' => $chart_data // Removed chart data from this main overview data call

--- a/wp-content/themes/mobooking/templates/email/default-email-template.php
+++ b/wp-content/themes/mobooking/templates/email/default-email-template.php
@@ -1,0 +1,136 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>%%BLOG_NAME%%</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <style type="text/css">
+    /* Base Styles */
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: Arial, sans-serif;
+      line-height: 1.6;
+      color: #333333;
+      background-color: #f4f4f4;
+      width: 100% !important;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    table td {
+      border-collapse: collapse;
+    }
+    img {
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+    }
+    p {
+      margin: 0 0 1em 0;
+    }
+    a {
+      color: #0073aa; /* WordPress blue */
+    }
+
+    /* Wrapper */
+    .email-wrapper {
+      width: 100%;
+      max-width: 600px;
+      margin: 0 auto;
+      background-color: #ffffff;
+    }
+
+    /* Header */
+    .email-header {
+      padding: 20px;
+      background-color: #0073aa; /* WordPress blue */
+      text-align: center;
+    }
+    .email-header h1 {
+      color: #ffffff;
+      font-size: 24px;
+      margin: 0;
+      font-weight: normal;
+    }
+    .email-header h1 a {
+      color: #ffffff;
+      text-decoration: none;
+    }
+    .email-header .site-logo {
+        max-height: 50px; /* Adjust as needed */
+        margin-bottom: 10px;
+    }
+
+
+    /* Content */
+    .email-content {
+      padding: 30px 20px;
+    }
+    .email-content h2 {
+      font-size: 20px;
+      color: #333333;
+      margin-top: 0;
+    }
+
+    /* Footer */
+    .email-footer {
+      padding: 20px;
+      background-color: #f9f9f9;
+      text-align: center;
+      font-size: 12px;
+      color: #777777;
+    }
+    .email-footer a {
+      color: #0073aa;
+    }
+
+    /* Responsive */
+    @media only screen and (max-width: 600px) {
+      .email-wrapper {
+        width: 100% !important;
+        max-width: none !important;
+      }
+      .email-content {
+        padding: 20px 15px !important;
+      }
+      .email-header h1 {
+        font-size: 20px !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <table width="100%" border="0" cellpadding="0" cellspacing="0" style="background-color:#f4f4f4;">
+    <tr>
+      <td align="center" valign="top">
+        <table class="email-wrapper" width="600" border="0" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border: 1px solid #dddddd;">
+          <!-- Header -->
+          <tr>
+            <td class="email-header" style="padding: 20px; background-color: #0073aa; text-align: center;">
+              %%EMAIL_HEADER_CONTENT%%
+            </td>
+          </tr>
+          <!-- Content -->
+          <tr>
+            <td class="email-content" style="padding: 30px 20px;">
+              %%EMAIL_CONTENT%%
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td class="email-footer" style="padding: 20px; background-color: #f9f9f9; text-align: center; font-size: 12px; color: #777777;">
+              <p>%%EMAIL_FOOTER_CONTENT%%</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
Here's how I'll approach it:
- I'll create a default HTML email template within the MoBooking theme.
- Then, I'll modify the `functions.php` file to:
    - Ensure email content is treated as HTML.
    - Establish a default 'from' name and email address for outgoing messages.
    - Enclose standard WordPress email content within the new HTML template. This will include a header (featuring your site logo or name), a main content area, and a footer.

This will give all emails sent from your website, like password resets and new user notifications, a consistent and branded appearance.