### PR TITLE
Fix: Ensure 'add slot' button works on newly enabled day

### DIFF
--- a/assets/js/dashboard-availability.js
+++ b/assets/js/dashboard-availability.js
@@ -193,12 +193,24 @@ jQuery(document).ready(function ($) {
 
     $dayItem.toggleClass('day-enabled', isEnabled).toggleClass('day-disabled', !isEnabled);
 
+    let dayData = scheduleData.find(d => d.day_of_week == dayIndex);
+    if (!dayData) {
+        dayData = { day_of_week: dayIndex, is_enabled: false, slots: [] };
+        scheduleData.push(dayData);
+    }
+    dayData.is_enabled = isEnabled;
+
     if (isEnabled) {
         $slotsContainer.html('');
-        // Add a default slot
-        const newSlot = { start_time: '09:00', end_time: '17:00' };
-        scheduleData.find(d => d.day_of_week == dayIndex).slots.push(newSlot);
-        $slotsContainer.append(renderSlotInput(dayIndex, 0, newSlot));
+        if (dayData.slots.length === 0) {
+            // Add a default slot
+            const newSlot = { start_time: '09:00', end_time: '17:00' };
+            dayData.slots.push(newSlot);
+        }
+        const totalSlots = dayData.slots.length;
+        dayData.slots.forEach((slot, index) => {
+            $slotsContainer.append(renderSlotInput(dayIndex, index, slot, totalSlots));
+        });
     } else {
         $slotsContainer.html(`<p class="day-off-text">${i18n.day_off_text || 'Unavailable'}</p>`);
     }


### PR DESCRIPTION
This commit fixes a bug where the 'add new time slot' button would not work on a day that was just enabled, without first saving the schedule. The issue was that the `dayData` object was not being created in the `scheduleData` array when a day was enabled.

The `day-toggle-switch` event handler has been updated to create the `dayData` object if it doesn't exist, which resolves the issue.