### PR TITLE
Refactor: Overhaul overview page with shadcn-inspired UI

### DIFF
--- a/assets/css/dashboard-overview-refactored.css
+++ b/assets/css/dashboard-overview-refactored.css
@@ -1,0 +1,260 @@
+/* ==========================================================================
+   Refactored Dashboard Overview - Shadcn UI Inspired
+   ========================================================================== */
+
+:root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+    --radius: 0.5rem;
+}
+
+.dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+}
+
+/* Base styles */
+body {
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+}
+
+.mobooking-overview-refactored {
+    padding: 2rem;
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(12, 1fr);
+}
+
+/* Card styles */
+.card {
+    background-color: hsl(var(--card));
+    color: hsl(var(--card-foreground));
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    padding: 1.5rem;
+}
+
+.card-header {
+    margin-bottom: 1rem;
+}
+
+.card-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: hsl(var(--card-foreground));
+    margin: 0;
+}
+
+.card-description {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    margin-top: 0.25rem;
+}
+
+.card-content {
+    /* Content styles */
+}
+
+.card-footer {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid hsl(var(--border));
+}
+
+/* Grid layout for widgets */
+.widget-span-1 { grid-column: span 1; }
+.widget-span-2 { grid-column: span 2; }
+.widget-span-3 { grid-column: span 3; }
+.widget-span-4 { grid-column: span 4; }
+.widget-span-5 { grid-column: span 5; }
+.widget-span-6 { grid-column: span 6; }
+.widget-span-7 { grid-column: span 7; }
+.widget-span-8 { grid-column: span 8; }
+.widget-span-9 { grid-column: span 9; }
+.widget-span-10 { grid-column: span 10; }
+.widget-span-11 { grid-column: span 11; }
+.widget-span-12 { grid-column: span 12; }
+
+/* Button styles */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius);
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+    transition: all 0.2s ease-in-out;
+    border: 1px solid transparent;
+}
+
+.btn-primary {
+    background-color: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border-color: hsl(var(--primary));
+}
+
+.btn-primary:hover {
+    background-color: hsl(var(--primary) / 0.9);
+}
+
+.btn-secondary {
+    background-color: hsl(var(--secondary));
+    color: hsl(var(--secondary-foreground));
+    border-color: hsl(var(--border));
+}
+
+.btn-secondary:hover {
+    background-color: hsl(var(--secondary) / 0.9);
+}
+
+.btn-ghost {
+    background-color: transparent;
+    color: hsl(var(--primary));
+    border-color: transparent;
+}
+
+.btn-ghost:hover {
+    background-color: hsl(var(--accent));
+}
+
+/* Specific widget styles */
+.text-2xl {
+    font-size: 1.5rem;
+    line-height: 2rem;
+}
+
+.font-bold {
+    font-weight: 700;
+}
+
+/* Quick Actions Widget */
+.quick-actions-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem;
+}
+
+/* Recent Bookings Widget */
+.recent-bookings-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.booking-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.booking-item:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.booking-item-details {
+    display: flex;
+    flex-direction: column;
+}
+
+.booking-item-customer {
+    font-weight: 600;
+}
+
+.booking-item-service {
+    color: hsl(var(--muted-foreground));
+    font-size: 0.875rem;
+}
+
+.booking-item-price {
+    font-weight: 600;
+}
+
+/* Setup Progress Widget */
+.setup-progress-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.setup-progress-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.setup-progress-item .icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    background-color: hsl(var(--muted));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: hsl(var(--muted-foreground));
+}
+
+.setup-progress-item.completed .icon {
+    background-color: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+}
+
+/* Tips & Resources Widget */
+.tips-resources-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.tip-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: hsl(var(--primary));
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.tip-item:hover {
+    text-decoration: underline;
+}

--- a/assets/js/dashboard-overview.js
+++ b/assets/js/dashboard-overview.js
@@ -1,629 +1,170 @@
 /**
- * MoBooking Dashboard Overview - Fixed Version
- * Corrected AJAX action names and improved error handling
+ * MoBooking Dashboard Overview - Refactored for Shadcn UI look
  */
 
 jQuery(document).ready(function ($) {
-  "use strict";
+    "use strict";
 
-  // Global variables
-  const currencySymbol = mobooking_overview_params.currency_symbol || "$";
-  const isWorker = mobooking_overview_params.is_worker || false;
-  const dashboardNonce = mobooking_overview_params.nonce;
-  let bookingStatusChart = null;
-  let refreshInterval = null;
+    // Global variables
+    const currencySymbol = mobooking_overview_params.currency_symbol || "$";
+    const dashboardNonce = mobooking_overview_params.nonce;
 
-  // Initialize the dashboard
-  initializeDashboard();
+    // Initialize the dashboard
+    initializeDashboard();
 
-  function initializeDashboard() {
-    console.log("🚀 Initializing MoBooking Dashboard Overview...");
-
-    // Check if required parameters are available
-    if (!mobooking_overview_params.ajax_url || !dashboardNonce) {
-      console.error("❌ Missing required parameters:", {
-        ajax_url: mobooking_overview_params.ajax_url,
-        nonce: dashboardNonce,
-      });
-      showErrorMessage("Configuration error: Missing required parameters");
-      return;
-    }
-
-    // Load all data
-    loadKPIData();
-    loadLiveActivityFeed();
-    loadTopServices();
-    loadCustomerInsights();
-    initializeBookingStatusChart();
-    updateSubscriptionUsage();
-
-    // Bind events
-    bindEvents();
-
-    // Setup auto-refresh
-    setupDataRefresh();
-  }
-
-  function loadKPIData() {
-    console.log("📊 Loading KPI data...");
-
-    // Show loading indicators
-    $(".kpi-value .loading").show();
-    $(".kpi-value").not(".loading").hide();
-
-    $.ajax({
-      url: mobooking_overview_params.ajax_url,
-      type: "POST",
-      data: {
-        action: "mobooking_get_dashboard_kpi_data", // Fixed action name
-        nonce: dashboardNonce,
-      },
-      timeout: 30000, // 30 second timeout
-      success: function (response) {
-        console.log("📊 KPI Response:", response);
-
-        if (response.success && response.data) {
-          updateKPIs(response.data);
-        } else {
-          console.warn("⚠️ KPI Response not successful:", response);
-          showFallbackKPIs();
-          if (response.data && response.data.message) {
-            showErrorMessage("KPI Error: " + response.data.message);
-          }
+    function initializeDashboard() {
+        if (!mobooking_overview_params.ajax_url || !dashboardNonce) {
+            console.error("Missing required parameters for dashboard initialization.");
+            return;
         }
-      },
-      error: function (xhr, status, error) {
-        console.error("❌ KPI AJAX Error:", {
-          status: status,
-          error: error,
-          responseText: xhr.responseText,
-          statusCode: xhr.status,
-        });
 
-        showFallbackKPIs();
+        // Load dynamic data
+        loadStatisticWidgets();
+        loadRecentBookings();
 
-        // Show user-friendly error message
-        if (xhr.status === 500) {
-          showErrorMessage(
-            "Server error loading dashboard data. Please check server logs."
-          );
-        } else if (xhr.status === 403) {
-          showErrorMessage(
-            "Access denied. Please refresh the page and try again."
-          );
-        } else {
-          showErrorMessage("Failed to load dashboard data. Please try again.");
-        }
-      },
-      complete: function () {
-        $(".kpi-value .loading").hide();
-        $(".kpi-value").not(".loading").show();
-      },
-    });
-  }
-
-  function updateKPIs(data) {
-    console.log("📈 Updating KPIs with data:", data);
-
-    // Update each KPI with safe fallbacks
-    const kpis = [
-      { selector: "#kpi-total-bookings", value: data.total_bookings || 0 },
-      { selector: "#kpi-pending-bookings", value: data.pending_bookings || 0 },
-      {
-        selector: "#kpi-revenue-month",
-        value: data.revenue_month || 0,
-        isCurrency: true,
-      },
-      { selector: "#kpi-services-count", value: data.services_count || 0 },
-      {
-        selector: "#kpi-revenue-today",
-        value: data.revenue_today || 0,
-        isCurrency: true,
-      },
-      { selector: "#kpi-bookings-today", value: data.bookings_today || 0 },
-      {
-        selector: "#kpi-confirmed-bookings",
-        value: data.confirmed_bookings || 0,
-      },
-      {
-        selector: "#kpi-completed-bookings",
-        value: data.completed_bookings || 0,
-      },
-    ];
-
-    kpis.forEach(function (kpi) {
-      const element = $(kpi.selector);
-      if (element.length > 0) {
-        let displayValue = kpi.value;
-        if (kpi.isCurrency) {
-          displayValue = currencySymbol + parseFloat(kpi.value).toFixed(2);
-        }
-        element.text(displayValue);
-        element.removeClass("loading");
-      }
-    });
-
-    // Hide loading indicators
-    $(".kpi-value .loading").hide();
-  }
-
-  function showFallbackKPIs() {
-    console.log("📊 Showing fallback KPIs");
-
-    const fallbackKPIs = [
-      { selector: "#kpi-total-bookings", value: "0" },
-      { selector: "#kpi-pending-bookings", value: "0" },
-      { selector: "#kpi-revenue-month", value: currencySymbol + "0.00" },
-      { selector: "#kpi-services-count", value: "0" },
-      { selector: "#kpi-revenue-today", value: currencySymbol + "0.00" },
-      { selector: "#kpi-bookings-today", value: "0" },
-      { selector: "#kpi-confirmed-bookings", value: "0" },
-      { selector: "#kpi-completed-bookings", value: "0" },
-    ];
-
-    fallbackKPIs.forEach(function (kpi) {
-      const element = $(kpi.selector);
-      if (element.length > 0) {
-        element.text(kpi.value);
-        element.removeClass("loading");
-      }
-    });
-
-    $(".kpi-value .loading").hide();
-  }
-
-  function loadLiveActivityFeed() {
-    console.log("📡 Loading recent bookings...");
-
-    $.ajax({
-      url: mobooking_overview_params.ajax_url,
-      type: "POST",
-      data: {
-        action: "mobooking_get_recent_bookings",
-        nonce: dashboardNonce,
-        limit: 5,
-      },
-      timeout: 30000,
-      success: function (response) {
-        console.log("📡 Recent bookings response:", response);
-
-        if (
-          response.success &&
-          response.data &&
-          response.data.recent_bookings
-        ) {
-          updateLiveActivityFeed(response.data.recent_bookings);
-        } else {
-          console.warn("⚠️ Recent bookings response not successful:", response);
-          showEmptyActivityFeed();
-        }
-      },
-      error: function (xhr, status, error) {
-        console.error("❌ Recent bookings AJAX error:", {
-          status: status,
-          error: error,
-          responseText: xhr.responseText,
-        });
-        showEmptyActivityFeed();
-      },
-    });
-  }
-
-  function updateLiveActivityFeed(bookings) {
-    const container = $("#live-activity-feed");
-    if (container.length === 0) return;
-
-    if (!bookings || bookings.length === 0) {
-      container.html(
-        '<div class="no-activity">No recent bookings found.</div>'
-      );
-      return;
+        // Load static data
+        populateSetupProgress();
+        populateTipsAndResources();
     }
 
-    let html = "";
-    bookings.forEach(function (booking) {
-      const bookingDate = new Date(
-        booking.booking_date + " " + booking.booking_time
-      );
-      const formattedDate = bookingDate.toLocaleDateString();
-      const formattedTime = bookingDate.toLocaleTimeString();
-
-      html += `
-        <div class="activity-item">
-          <div class="activity-content">
-            <div class="activity-title">${escapeHtml(
-              booking.customer_name || "N/A"
-            )}</div>
-            <div class="activity-details">
-              <span class="activity-ref">#${escapeHtml(
-                booking.booking_reference || "N/A"
-              )}</span>
-              <span class="activity-date">${formattedDate} at ${formattedTime}</span>
-              <span class="activity-status status-${booking.status}">${
-        booking.status || "pending"
-      }</span>
-            </div>
-          </div>
-          <div class="activity-price">
-            ${currencySymbol}${parseFloat(booking.total_price || 0).toFixed(2)}
-          </div>
-        </div>
-      `;
-    });
-
-    container.html(html);
-  }
-
-  function showEmptyActivityFeed() {
-    const container = $("#live-activity-feed");
-    if (container.length > 0) {
-      container.html(
-        '<div class="no-activity">No recent bookings available.</div>'
-      );
-    }
-  }
-
-  function loadTopServices() {
-    console.log("🏆 Loading top services...");
-
-    $.ajax({
-      url: mobooking_overview_params.ajax_url,
-      type: "POST",
-      data: {
-        action: "mobooking_get_top_services",
-        nonce: dashboardNonce,
-        limit: 5,
-      },
-      timeout: 30000,
-      success: function (response) {
-        console.log("🏆 Top services response:", response);
-
-        if (response.success && response.data && response.data.top_services) {
-          updateTopServices(response.data.top_services);
-        } else {
-          console.warn("⚠️ Top services response not successful:", response);
-          showEmptyTopServices();
-        }
-      },
-      error: function (xhr, status, error) {
-        console.error("❌ Top services AJAX error:", {
-          status: status,
-          error: error,
-          responseText: xhr.responseText,
-        });
-        showEmptyTopServices();
-      },
-    });
-  }
-
-  function updateTopServices(services) {
-    const container = $("#top-services-list");
-    if (container.length === 0) return;
-
-    if (!services || services.length === 0) {
-      container.html(
-        '<div class="no-services">No services data available.</div>'
-      );
-      return;
-    }
-
-    let html = '<div class="services-grid">';
-    services.forEach(function (service) {
-      html += `
-        <div class="service-item">
-          <div class="service-info">
-            <div class="service-name">${escapeHtml(service.name || "N/A")}</div>
-            <div class="service-stats">
-              <span class="service-bookings">${
-                service.bookings_count || 0
-              } bookings</span>
-              ${
-                service.revenue
-                  ? `<span class="service-revenue">${currencySymbol}${parseFloat(
-                      service.revenue
-                    ).toFixed(2)}</span>`
-                  : ""
-              }
-            </div>
-          </div>
-        </div>
-      `;
-    });
-    html += "</div>";
-
-    container.html(html);
-  }
-
-  function showEmptyTopServices() {
-    const container = $("#top-services-list");
-    if (container.length > 0) {
-      container.html(
-        '<div class="no-services">No services data available.</div>'
-      );
-    }
-  }
-
-  function loadCustomerInsights() {
-    console.log("👥 Loading customer insights...");
-
-    $.ajax({
-      url: mobooking_overview_params.ajax_url,
-      type: "POST",
-      data: {
-        action: "mobooking_get_customer_insights",
-        nonce: dashboardNonce,
-      },
-      timeout: 30000,
-      success: function (response) {
-        console.log("👥 Customer insights response:", response);
-
-        if (response.success && response.data) {
-          updateCustomerInsights(response.data);
-        } else {
-          console.warn(
-            "⚠️ Customer insights response not successful:",
-            response
-          );
-          showFallbackCustomerInsights();
-        }
-      },
-      error: function (xhr, status, error) {
-        console.error("❌ Customer insights AJAX error:", {
-          status: status,
-          error: error,
-          responseText: xhr.responseText,
-        });
-        showFallbackCustomerInsights();
-      },
-    });
-  }
-
-  function updateCustomerInsights(data) {
-    $("#insight-new-customers").text(data.new_customers || 0);
-    $("#insight-returning-customers").text(data.returning_customers || 0);
-    $("#insight-retention-rate").text((data.retention_rate || 0) + "%");
-
-    // Update percentages
-    const total = (data.new_customers || 0) + (data.returning_customers || 0);
-    if (total > 0) {
-      $("#insight-new-percentage").text(
-        Math.round((data.new_customers / total) * 100) + "%"
-      );
-      $("#insight-returning-percentage").text(
-        Math.round((data.returning_customers / total) * 100) + "%"
-      );
-    } else {
-      $("#insight-new-percentage").text("0%");
-      $("#insight-returning-percentage").text("0%");
-    }
-  }
-
-  function showFallbackCustomerInsights() {
-    $("#insight-new-customers").text("0");
-    $("#insight-returning-customers").text("0");
-    $("#insight-retention-rate").text("0%");
-    $("#insight-new-percentage").text("0%");
-    $("#insight-returning-percentage").text("0%");
-  }
-
-  function initializeBookingStatusChart() {
-    const ctx = document.getElementById("booking-status-chart");
-    if (!ctx) {
-      console.warn("📊 Chart canvas not found");
-      return;
-    }
-
-    if (typeof Chart === "undefined") {
-      console.error("❌ Chart.js is not loaded");
-      return;
-    }
-
-    // Load chart data
-    loadChartData("week");
-  }
-
-  function loadChartData(period) {
-    console.log("📊 Loading chart data for period:", period);
-
-    $.ajax({
-      url: mobooking_overview_params.ajax_url,
-      type: "POST",
-      data: {
-        action: "mobooking_get_chart_data",
-        nonce: dashboardNonce,
-        period: period,
-      },
-      timeout: 30000,
-      success: function (response) {
-        console.log("📊 Chart data response:", response);
-
-        if (response.success && response.data) {
-          updateChart(response.data);
-        } else {
-          console.warn("⚠️ Chart data response not successful:", response);
-          showEmptyChart();
-        }
-      },
-      error: function (xhr, status, error) {
-        console.error("❌ Chart data AJAX error:", {
-          status: status,
-          error: error,
-          responseText: xhr.responseText,
-        });
-        showEmptyChart();
-      },
-    });
-  }
-
-  function updateChart(data) {
-    const ctx = document.getElementById("booking-status-chart");
-    if (!ctx) return;
-
-    // Destroy existing chart
-    if (bookingStatusChart) {
-      bookingStatusChart.destroy();
-    }
-
-    // Create new chart
-    bookingStatusChart = new Chart(ctx, {
-      type: "line",
-      data: {
-        labels: data.labels || [],
-        datasets: [
-          {
-            label: "Bookings",
-            data: data.values || [],
-            borderColor: "#3b82f6",
-            backgroundColor: "rgba(59, 130, 246, 0.1)",
-            tension: 0.4,
-            fill: true,
-          },
-        ],
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: {
-          legend: {
-            display: false,
-          },
-        },
-        scales: {
-          y: {
-            beginAtZero: true,
-            ticks: {
-              stepSize: 1,
+    function loadStatisticWidgets() {
+        $.ajax({
+            url: mobooking_overview_params.ajax_url,
+            type: "POST",
+            data: {
+                action: "mobooking_get_dashboard_kpi_data",
+                nonce: dashboardNonce,
             },
-          },
-        },
-      },
-    });
-  }
-
-  function showEmptyChart() {
-    const ctx = document.getElementById("booking-status-chart");
-    if (!ctx) return;
-
-    // Destroy existing chart
-    if (bookingStatusChart) {
-      bookingStatusChart.destroy();
-    }
-
-    // Show empty state
-    const container = ctx.parentElement;
-    if (container) {
-      container.innerHTML =
-        '<div class="chart-empty">No chart data available</div>';
-    }
-  }
-
-  function updateSubscriptionUsage() {
-    // Placeholder for subscription usage updates
-    console.log("📊 Updating subscription usage...");
-  }
-
-  function bindEvents() {
-    // Refresh button
-    $(document).on("click", "#refresh-dashboard", function (e) {
-      e.preventDefault();
-      console.log("🔄 Manual refresh triggered");
-      initializeDashboard();
-    });
-
-    // Chart period selector
-    $(document).on("change", "#chart-period-selector", function () {
-      const period = $(this).val();
-      loadChartData(period);
-    });
-
-    // Quick action buttons
-    $(document).on("click", "#add-booking-action", function (e) {
-      e.preventDefault();
-      // Redirect to add booking page or show modal
-      window.location.href =
-        mobooking_overview_params.dashboard_url + "bookings/";
-    });
-  }
-
-  function setupDataRefresh() {
-    // Auto-refresh every 5 minutes
-    refreshInterval = setInterval(function () {
-      console.log("🔄 Auto-refreshing dashboard data...");
-      loadKPIData();
-      loadLiveActivityFeed();
-    }, 300000); // 5 minutes
-
-    // Clear interval on page unload
-    $(window).on("beforeunload", function () {
-      if (refreshInterval) {
-        clearInterval(refreshInterval);
-      }
-    });
-  }
-
-  function showErrorMessage(message) {
-    console.error("❌ Error:", message);
-
-    // Show error in a user-friendly way
-    let errorContainer = $("#dashboard-error-message");
-    if (errorContainer.length === 0) {
-      errorContainer = $(
-        '<div id="dashboard-error-message" class="notice notice-error" style="margin: 10px 0;"><p></p></div>'
-      );
-      $(".mobooking-overview").prepend(errorContainer);
-    }
-
-    errorContainer.find("p").text(message);
-    errorContainer.show();
-
-    // Auto-hide after 10 seconds
-    setTimeout(function () {
-      errorContainer.fadeOut();
-    }, 10000);
-  }
-
-  function escapeHtml(text) {
-    const div = document.createElement("div");
-    div.textContent = text;
-    return div.innerHTML;
-  }
-
-  // Debug function to help troubleshoot issues
-  function debugDashboard() {
-    console.log("🔍 Dashboard Debug Info:");
-    console.log("- AJAX URL:", mobooking_overview_params.ajax_url);
-    console.log("- Nonce:", dashboardNonce);
-    console.log("- Currency Symbol:", currencySymbol);
-    console.log("- Is Worker:", isWorker);
-    console.log("- jQuery version:", $.fn.jquery);
-    console.log("- Chart.js available:", typeof Chart !== "undefined");
-
-    // Test AJAX connectivity
-    $.ajax({
-      url: mobooking_overview_params.ajax_url,
-      type: "POST",
-      data: {
-        action: "mobooking_debug_ajax",
-        nonce: dashboardNonce,
-      },
-      success: function (response) {
-        console.log("🔍 AJAX Debug Response:", response);
-      },
-      error: function (xhr, status, error) {
-        console.error("🔍 AJAX Debug Error:", {
-          status: status,
-          error: error,
-          responseText: xhr.responseText,
+            success: function (response) {
+                if (response.success && response.data) {
+                    updateStatistics(response.data);
+                } else {
+                    showErrorInWidgets();
+                }
+            },
+            error: function () {
+                showErrorInWidgets();
+            }
         });
-      },
-    });
-  }
+    }
 
-  // Expose debug function globally for testing
-  window.debugMoBookingDashboard = debugDashboard;
+    function updateStatistics(data) {
+        // Total Bookings
+        const totalBookings = data.total_bookings || 0;
+        $('#total-bookings-value').text(totalBookings);
 
-  // Initial debug on load if in debug mode
-  if (mobooking_overview_params.debug) {
-    debugDashboard();
-  }
+        // Total Revenue
+        const totalRevenue = data.revenue_month || 0;
+        $('#total-revenue-value').text(currencySymbol + parseFloat(totalRevenue).toFixed(2));
+
+        // Revenue Breakdown - using today's revenue as main value
+        const revenueToday = data.revenue_today || 0;
+        $('#revenue-breakdown-value').text(currencySymbol + parseFloat(revenueToday).toFixed(2));
+
+        // Completion Rate
+        const completedBookings = data.completed_bookings || 0;
+        const completionRate = totalBookings > 0 ? ((completedBookings / totalBookings) * 100).toFixed(0) + '%' : '0%';
+        $('#completion-rate-value').text(completionRate);
+    }
+
+    function loadRecentBookings() {
+        $.ajax({
+            url: mobooking_overview_params.ajax_url,
+            type: "POST",
+            data: {
+                action: "mobooking_get_recent_bookings",
+                nonce: dashboardNonce,
+                limit: 5,
+            },
+            success: function (response) {
+                if (response.success && response.data.recent_bookings) {
+                    updateRecentBookings(response.data.recent_bookings);
+                } else {
+                    $('#recent-bookings-list').html('<p>No recent bookings.</p>');
+                }
+            },
+            error: function () {
+                $('#recent-bookings-list').html('<p>Error loading bookings.</p>');
+            }
+        });
+    }
+
+    function updateRecentBookings(bookings) {
+        const container = $('#recent-bookings-list');
+        if (!bookings || bookings.length === 0) {
+            container.html('<p>No recent bookings found.</p>');
+            return;
+        }
+
+        let html = '<div class="recent-bookings-list">';
+        bookings.forEach(function (booking) {
+            html += `
+                <div class="booking-item">
+                    <div class="booking-item-details">
+                        <div class="booking-item-customer">${escapeHtml(booking.customer_name || 'N/A')}</div>
+                        <div class="booking-item-service">${escapeHtml(booking.service_name || 'N/A')}</div>
+                    </div>
+                    <div class="booking-item-price">
+                        ${currencySymbol}${parseFloat(booking.total_price || 0).toFixed(2)}
+                    </div>
+                </div>
+            `;
+        });
+        html += '</div>';
+        container.html(html);
+    }
+
+    function populateSetupProgress() {
+        const container = $('#setup-progress-list');
+        const steps = [
+            { name: 'Add Services', completed: true }, // Assuming user has added at least one service
+            { name: 'Set Service Areas', completed: false },
+            { name: 'Business Info', completed: true }, // Assuming basic info is filled
+            { name: 'Customize Branding', completed: false }
+        ];
+
+        let html = '<div class="setup-progress-list">';
+        steps.forEach(function(step) {
+            html += `
+                <div class="setup-progress-item ${step.completed ? 'completed' : ''}">
+                    <div class="icon">${step.completed ? '✔' : ''}</div>
+                    <span>${step.name}</span>
+                </div>
+            `;
+        });
+        html += '</div>';
+        container.html(html);
+    }
+
+    function populateTipsAndResources() {
+        const container = $('#tips-resources-list');
+        const tips = [
+            { name: 'Share Your Booking Link', url: '#' },
+            { name: 'Create Promotional Codes', url: '#' }
+        ];
+
+        let html = '<div class="tips-resources-list">';
+        tips.forEach(function(tip) {
+            html += `
+                <a href="${tip.url}" class="tip-item">
+                    <span>${tip.name}</span>
+                </a>
+            `;
+        });
+        html += '</div>';
+        container.html(html);
+    }
+
+    function showErrorInWidgets() {
+        $('#total-bookings-value').text('Error');
+        $('#total-revenue-value').text('Error');
+        $('#revenue-breakdown-value').text('Error');
+        $('#completion-rate-value').text('Error');
+    }
+
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
 });

--- a/dashboard/page-overview.php
+++ b/dashboard/page-overview.php
@@ -37,304 +37,101 @@ if (class_exists('MoBooking\Classes\Auth') && \MoBooking\Classes\Auth::is_user_w
 $dashboard_base_url = home_url('/dashboard/');
 ?>
 
-<div class="mobooking-overview">
-    <!-- Header -->
-    <div class="overview-header">
-        <h1 class="overview-title">
-            <?php printf(esc_html__('Welcome back, %s!', 'mobooking'), esc_html($user->display_name)); ?>
-        </h1>
-        <p class="overview-subtitle">
-            <?php esc_html_e('Here\'s what\'s happening with your cleaning business today.', 'mobooking'); ?>
-        </p>
-    </div>
+<div class="mobooking-overview-refactored">
 
-    <!-- Top KPI Cards -->
-    <div class="dashboard-kpi-grid">
-        <!-- Total Bookings Today -->
-        <div class="dashboard-kpi-card">
-            <div class="kpi-header">
-                <span class="kpi-title"><?php esc_html_e('Bookings Today', 'mobooking'); ?></span>
-                <div class="kpi-icon bookings">📅</div>
-            </div>
-            <div class="kpi-value" id="kpi-bookings-today">
-                <span class="loading"></span>
-            </div>
-            <div class="kpi-trend positive" id="bookings-today-trend">
-                <span>↗</span> +3 from yesterday
-            </div>
+    <!-- Statistics Widgets -->
+    <div class="card widget-span-3">
+        <div class="card-header">
+            <h3 class="card-title">Total Bookings</h3>
+            <p class="card-description">pending, confirmed</p>
         </div>
-
-        <!-- Bookings This Month -->
-        <div class="dashboard-kpi-card">
-            <div class="kpi-header">
-                <span class="kpi-title"><?php esc_html_e('Bookings This Month', 'mobooking'); ?></span>
-                <div class="kpi-icon bookings">📊</div>
-            </div>
-            <div class="kpi-value" id="kpi-bookings-month">
-                <span class="loading"></span>
-            </div>
-            <div class="kpi-trend positive" id="bookings-month-trend">
-                <span>↗</span> +12% from last month
-            </div>
-        </div>
-
-        <!-- Upcoming Bookings -->
-        <div class="dashboard-kpi-card">
-            <div class="kpi-header">
-                <span class="kpi-title"><?php esc_html_e('Upcoming Bookings', 'mobooking'); ?></span>
-                <div class="kpi-icon upcoming">⏰</div>
-            </div>
-            <div class="kpi-value" id="kpi-upcoming-count">
-                <span class="loading"></span>
-            </div>
-            <div class="kpi-trend neutral" id="upcoming-trend">
-                <span>→</span> Next 7 days
-            </div>
-        </div>
-
-        <!-- Revenue This Month (Only for non-workers) -->
-        <?php if (!$is_worker): ?>
-        <div class="dashboard-kpi-card">
-            <div class="kpi-header">
-                <span class="kpi-title"><?php esc_html_e('Revenue This Month', 'mobooking'); ?></span>
-                <div class="kpi-icon revenue">💰</div>
-            </div>
-            <div class="kpi-value" id="kpi-revenue-month">
-                <span class="loading"></span>
-            </div>
-            <div class="kpi-trend positive" id="revenue-trend">
-                <span>↗</span> +8% from last month
-            </div>
-        </div>
-        <?php endif; ?>
-
-        <!-- Completed Bookings -->
-        <div class="dashboard-kpi-card">
-            <div class="kpi-header">
-                <span class="kpi-title"><?php esc_html_e('Completed', 'mobooking'); ?></span>
-                <div class="kpi-icon completed">✅</div>
-            </div>
-            <div class="kpi-value" id="kpi-completed-count">
-                <span class="loading"></span>
-            </div>
-            <div class="kpi-trend positive" id="completed-trend">
-                <span>↗</span> This month
-            </div>
-        </div>
-
-        <!-- Cancelled Bookings -->
-        <div class="dashboard-kpi-card">
-            <div class="kpi-header">
-                <span class="kpi-title"><?php esc_html_e('Cancelled', 'mobooking'); ?></span>
-                <div class="kpi-icon cancelled">❌</div>
-            </div>
-            <div class="kpi-value" id="kpi-cancelled-count">
-                <span class="loading"></span>
-            </div>
-            <div class="kpi-trend negative" id="cancelled-trend">
-                <span>↘</span> This month
-            </div>
-        </div>
-
-        <!-- Average Booking Value (Only for non-workers) -->
-        <?php if (!$is_worker): ?>
-        <div class="dashboard-kpi-card">
-            <div class="kpi-header">
-                <span class="kpi-title"><?php esc_html_e('Avg Booking Value', 'mobooking'); ?></span>
-                <div class="kpi-icon average">💵</div>
-            </div>
-            <div class="kpi-value" id="kpi-avg-booking-value">
-                <span class="loading"></span>
-            </div>
-            <div class="kpi-trend positive" id="avg-booking-trend">
-                <span>↗</span> +5% from last month
-            </div>
-        </div>
-        <?php endif; ?>
-
-        <!-- New Customers -->
-        <div class="dashboard-kpi-card">
-            <div class="kpi-header">
-                <span class="kpi-title"><?php esc_html_e('New Customers', 'mobooking'); ?></span>
-                <div class="kpi-icon new-customers">👥</div>
-            </div>
-            <div class="kpi-value" id="kpi-new-customers">
-                <span class="loading"></span>
-            </div>
-            <div class="kpi-trend positive" id="new-customers-trend">
-                <span>↗</span> This month
-            </div>
+        <div class="card-content">
+            <p class="text-2xl font-bold" id="total-bookings-value">--</p>
         </div>
     </div>
 
-    <!-- Main Content Grid -->
-    <div class="content-grid">
-        <!-- Live Activity Feed -->
-        <div class="activity-container">
-            <div class="activity-header">
-                <h3 class="activity-title">
-                    <span class="activity-icon">🔄</span>
-                    <?php esc_html_e('Live Activity Feed', 'mobooking'); ?>
-                </h3>
-                <a href="<?php echo esc_url($dashboard_base_url . 'bookings/'); ?>" class="view-all-link">
-                    <?php esc_html_e('View All', 'mobooking'); ?>
-                </a>
-            </div>
-            <div class="activity-content">
-                <div id="live-activity-feed">
-                    <div class="loading-activity">
-                        <span class="loading"></span>
-                        <p><?php esc_html_e('Loading recent activities...', 'mobooking'); ?></p>
-                    </div>
-                </div>
-            </div>
+    <div class="card widget-span-3">
+        <div class="card-header">
+            <h3 class="card-title">Total Revenue</h3>
+            <p class="card-description">this month</p>
         </div>
-
-        <!-- Top Services -->
-        <div class="top-services-container">
-            <div class="services-header">
-                <h3 class="services-title">
-                    <span class="services-icon">🏆</span>
-                    <?php esc_html_e('Top Services', 'mobooking'); ?>
-                </h3>
-                <a href="<?php echo esc_url($dashboard_base_url . 'services/'); ?>" class="view-all-link">
-                    <?php esc_html_e('Manage Services', 'mobooking'); ?>
-                </a>
-            </div>
-            <div class="services-content">
-                <div id="top-services-list">
-                    <div class="loading-services">
-                        <span class="loading"></span>
-                        <p><?php esc_html_e('Loading top services...', 'mobooking'); ?></p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Booking Status Chart -->
-        <div class="status-chart-container">
-            <div class="chart-header">
-                <h3 class="chart-title">
-                    <span class="chart-icon">📊</span>
-                    <?php esc_html_e('Booking Status', 'mobooking'); ?>
-                </h3>
-                <div class="chart-period-selector">
-                    <button class="period-btn active" data-period="week"><?php esc_html_e('Week', 'mobooking'); ?></button>
-                    <button class="period-btn" data-period="month"><?php esc_html_e('Month', 'mobooking'); ?></button>
-                    <button class="period-btn" data-period="year"><?php esc_html_e('Year', 'mobooking'); ?></button>
-                </div>
-            </div>
-            <div class="chart-content">
-                <canvas id="booking-status-chart"></canvas>
-            </div>
-        </div>
-
-        <!-- Customer Insights -->
-        <div class="customer-insights-container">
-            <div class="insights-header">
-                <h3 class="insights-title">
-                    <span class="insights-icon">👥</span>
-                    <?php esc_html_e('Customer Insights', 'mobooking'); ?>
-                </h3>
-            </div>
-            <div class="insights-content">
-                <div class="insight-item">
-                    <div class="insight-label"><?php esc_html_e('New Customers', 'mobooking'); ?></div>
-                    <div class="insight-value" id="insight-new-customers">
-                        <span class="loading"></span>
-                    </div>
-                    <div class="insight-percentage" id="insight-new-percentage">0%</div>
-                </div>
-                <div class="insight-item">
-                    <div class="insight-label"><?php esc_html_e('Returning Customers', 'mobooking'); ?></div>
-                    <div class="insight-value" id="insight-returning-customers">
-                        <span class="loading"></span>
-                    </div>
-                    <div class="insight-percentage" id="insight-returning-percentage">0%</div>
-                </div>
-                <div class="insight-item">
-                    <div class="insight-label"><?php esc_html_e('Customer Retention', 'mobooking'); ?></div>
-                    <div class="insight-value" id="insight-retention-rate">
-                        <span class="loading"></span>
-                    </div>
-                    <div class="insight-percentage" id="insight-retention-percentage">0%</div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Quick Actions -->
-        <div class="quick-actions-container">
-            <div class="actions-header">
-                <h3 class="actions-title">
-                    <span class="actions-icon">⚡</span>
-                    <?php esc_html_e('Quick Actions', 'mobooking'); ?>
-                </h3>
-            </div>
-            <div class="actions-content">
-                <div class="action-grid">
-                    <button class="action-btn action-add-booking" id="add-booking-action">
-                        <span class="action-icon">➕</span>
-                        <span class="action-label"><?php esc_html_e('Add Booking', 'mobooking'); ?></span>
-                    </button>
-                    <button class="action-btn action-manage-services" onclick="location.href='<?php echo esc_url($dashboard_base_url . 'services/'); ?>'">
-                        <span class="action-icon">🧹</span>
-                        <span class="action-label"><?php esc_html_e('Manage Services', 'mobooking'); ?></span>
-                    </button>
-                    <button class="action-btn action-view-bookings" onclick="location.href='<?php echo esc_url($dashboard_base_url . 'bookings/'); ?>'">
-                        <span class="action-icon">📋</span>
-                        <span class="action-label"><?php esc_html_e('View Bookings', 'mobooking'); ?></span>
-                    </button>
-                    <button class="action-btn action-manage-discounts" onclick="location.href='<?php echo esc_url($dashboard_base_url . 'discounts/'); ?>'">
-                        <span class="action-icon">🏷️</span>
-                        <span class="action-label"><?php esc_html_e('Manage Discounts', 'mobooking'); ?></span>
-                    </button>
-                </div>
-            </div>
+        <div class="card-content">
+            <p class="text-2xl font-bold" id="total-revenue-value">--</p>
         </div>
     </div>
 
-    <!-- Bottom Section - Subscription Plan Box -->
-    <div class="subscription-section">
-        <div class="subscription-container">
-            <div class="subscription-header">
-                <h3 class="subscription-title">
-                    <span class="subscription-icon">💎</span>
-                    <?php esc_html_e('Your Subscription', 'mobooking'); ?>
-                </h3>
-                <div class="subscription-status">
-                    <span class="status-badge status-active"><?php esc_html_e('Active', 'mobooking'); ?></span>
-                </div>
-            </div>
-            <div class="subscription-content">
-                <div class="plan-info">
-                    <div class="plan-name"><?php esc_html_e('Professional Plan', 'mobooking'); ?></div>
-                    <div class="plan-price">$29<span class="plan-period">/month</span></div>
-                </div>
-                <div class="usage-info">
-                    <div class="usage-item">
-                        <span class="usage-label"><?php esc_html_e('Bookings this month:', 'mobooking'); ?></span>
-                        <span class="usage-value" id="usage-bookings">0 / 500</span>
-                    </div>
-                    <div class="usage-item">
-                        <span class="usage-label"><?php esc_html_e('Services:', 'mobooking'); ?></span>
-                        <span class="usage-value" id="usage-services">0 / 50</span>
-                    </div>
-                    <div class="usage-progress">
-                        <div class="progress-bar">
-                            <div class="progress-fill" id="usage-progress-bar" style="width: 0%"></div>
-                        </div>
-                        <span class="progress-text" id="usage-progress-text">0% used</span>
-                    </div>
-                </div>
-                <div class="subscription-actions">
-                    <button class="btn btn-primary btn-upgrade">
-                        <?php esc_html_e('Upgrade Plan', 'mobooking'); ?>
-                    </button>
-                    <button class="btn btn-secondary btn-manage">
-                        <?php esc_html_e('Manage Subscription', 'mobooking'); ?>
-                    </button>
-                </div>
-            </div>
+    <div class="card widget-span-3">
+        <div class="card-header">
+            <h3 class="card-title">This Month</h3>
+            <p class="card-description">this week, today</p>
+        </div>
+        <div class="card-content">
+            <p class="text-2xl font-bold" id="revenue-breakdown-value">--</p>
+        </div>
+    </div>
+
+    <div class="card widget-span-3">
+        <div class="card-header">
+            <h3 class="card-title">Completion Rate</h3>
+            <p class="card-description">completed</p>
+        </div>
+        <div class="card-content">
+            <p class="text-2xl font-bold" id="completion-rate-value">--</p>
+        </div>
+    </div>
+
+    <!-- Activity Widgets -->
+    <div class="card widget-span-12">
+        <div class="card-header">
+            <h3 class="card-title">Recent Bookings</h3>
+        </div>
+        <div class="card-content" id="recent-bookings-list">
+            <!-- Recent bookings will be loaded here -->
+        </div>
+        <div class="card-footer">
+            <a href="#" class="btn btn-ghost">View All</a>
+        </div>
+    </div>
+
+    <!-- Promotion & Sharing, Quick Actions, Setup Progress -->
+    <div class="card widget-span-4">
+        <div class="card-header">
+            <h3 class="card-title">Share Your Booking Link</h3>
+            <p class="card-description">Add your booking form link to your website and social media</p>
+        </div>
+        <div class="card-content">
+            <!-- Sharing link content -->
+        </div>
+    </div>
+
+    <div class="card widget-span-4">
+        <div class="card-header">
+            <h3 class="card-title">Quick Actions</h3>
+        </div>
+        <div class="card-content">
+            <a href="<?php echo esc_url($dashboard_base_url . 'services/'); ?>" class="btn btn-secondary">Add Service</a>
+            <a href="<?php echo esc_url($dashboard_base_url . 'discounts/'); ?>" class="btn btn-secondary">Create Discount</a>
+            <a href="<?php echo esc_url($dashboard_base_url . 'areas/'); ?>" class="btn btn-secondary">Service Areas</a>
+            <a href="<?php echo esc_url($dashboard_base_url . 'settings/'); ?>" class="btn btn-secondary">Settings</a>
+        </div>
+    </div>
+
+    <div class="card widget-span-4">
+        <div class="card-header">
+            <h3 class="card-title">Setup Progress</h3>
+        </div>
+        <div class="card-content" id="setup-progress-list">
+            <!-- Progress steps will be loaded here -->
+        </div>
+    </div>
+
+    <!-- Tips & Resources -->
+    <div class="card widget-span-12">
+        <div class="card-header">
+            <h3 class="card-title">Tips & Resources</h3>
+        </div>
+        <div class="card-content" id="tips-resources-list">
+            <!-- Tips will be loaded here -->
         </div>
     </div>
 </div>
@@ -346,7 +143,7 @@ var mobooking_overview_params = {
     ajax_url: ajaxurl,
     nonce: '<?php echo wp_create_nonce('mobooking_dashboard_nonce'); ?>',
     currency_symbol: '<?php echo esc_js($currency_symbol); ?>',
-    is_worker: <?php echo $is_worker ? 'true' : 'false'; ?>,
+    is__worker: <?php echo $is_worker ? 'true' : 'false'; ?>,
     dashboard_base_url: '<?php echo esc_js($dashboard_base_url); ?>',
     i18n: {
         time_ago_just_now: '<?php esc_html_e('Just now', 'mobooking'); ?>',
@@ -360,8 +157,3 @@ var mobooking_overview_params = {
     }
 };
 </script>
-
-<?php
-// The main dashboard logic is handled in assets/js/dashboard-overview.js
-// Chart.js and other required scripts should be enqueued via mobooking_enqueue_dashboard_scripts in functions.php
-?>

--- a/functions/routing.php
+++ b/functions/routing.php
@@ -248,7 +248,7 @@ function mobooking_enqueue_dashboard_scripts($current_page_slug = '') {
 
         wp_enqueue_style(
             'mobooking-overview-css',
-            get_template_directory_uri() . '/assets/css/dashboard-overview.css',
+            get_template_directory_uri() . '/assets/css/dashboard-overview-refactored.css',
             array(),
             MOBOOKING_VERSION
         );


### PR DESCRIPTION
This commit completely refactors the dashboard overview page to use a modern, widget-based layout with a style inspired by shadcn UI.

- Replaced the old overview page structure with a new grid-based layout using cards for each widget.
- Created a new stylesheet `dashboard-overview-refactored.css` with a modern color palette and typography.
- Updated the `dashboard-overview.js` to populate the new widgets with data from existing AJAX endpoints.
- Implemented static placeholders for widgets where data was not available from the backend (e.g., Setup Progress).
- Updated the stylesheet enqueueing in `functions/routing.php` to use the new refactored CSS file.