### PR TITLE
Feat: Update KPI cards to match specific HTML structure

### DIFF
--- a/assets/css/dashboard-overview-refactored.css
+++ b/assets/css/dashboard-overview-refactored.css
@@ -97,19 +97,12 @@ body {
     border-top: 1px solid hsl(var(--border));
 }
 
-/* Grid layout for widgets */
-.widget-span-1 { grid-column: span 1; }
-.widget-span-2 { grid-column: span 2; }
-.widget-span-3 { grid-column: span 3; }
-.widget-span-4 { grid-column: span 4; }
-.widget-span-5 { grid-column: span 5; }
-.widget-span-6 { grid-column: span 6; }
-.widget-span-7 { grid-column: span 7; }
-.widget-span-8 { grid-column: span 8; }
-.widget-span-9 { grid-column: span 9; }
-.widget-span-10 { grid-column: span 10; }
-.widget-span-11 { grid-column: span 11; }
-.widget-span-12 { grid-column: span 12; }
+.dashboard-kpi-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
 
 /* Button styles */
 .btn {
@@ -188,38 +181,28 @@ body {
     0 2px 4px -2px rgba(0, 0, 0, 0.1);
 }
 
-.dashboard-kpi-card .card-header {
+.kpi-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 0.75rem;
 }
 
-.dashboard-kpi-card .card-title {
+.kpi-title {
   font-size: 0.875rem;
   font-weight: 500;
   color: hsl(var(--muted-foreground));
-  text-transform: uppercase;
-  letter-spacing: 0.025em;
 }
 
-.dashboard-kpi-card .card-content {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-}
-
-.dashboard-kpi-card .feather {
+.kpi-icon img {
   width: 2rem;
   height: 2rem;
-  color: hsl(var(--primary));
 }
 
-.dashboard-kpi-card .text-2xl {
+.kpi-value {
   font-size: 1.875rem;
   font-weight: 700;
   color: hsl(var(--foreground));
-  margin-bottom: 0.25rem;
   line-height: 1.2;
 }
 

--- a/dashboard/page-overview.php
+++ b/dashboard/page-overview.php
@@ -49,47 +49,37 @@ $dashboard_base_url = home_url('/dashboard/');
     </div>
 
     <!-- Statistics Widgets -->
-    <div class="dashboard-kpi-card widget-span-3">
-        <div class="card-header">
-            <h3 class="card-title">Total Bookings</h3>
-            <p class="card-description">pending, confirmed</p>
+    <div class="dashboard-kpi-grid mobooking-overview-kpis">
+        <div class="dashboard-kpi-card">
+            <div class="kpi-header">
+                <span class="kpi-title">Total Bookings</span>
+                <div class="kpi-icon bookings"><img draggable="false" role="img" class="emoji" alt="📅" src="https://s.w.org/images/core/emoji/16.0.1/svg/1f4c5.svg"></div>
+            </div>
+            <div class="kpi-value" id="total-bookings-value">--</div>
         </div>
-        <div class="card-content">
-            <i data-feather="book"></i>
-            <p class="text-2xl font-bold" id="total-bookings-value">--</p>
-        </div>
-    </div>
 
-    <div class="dashboard-kpi-card widget-span-3">
-        <div class="card-header">
-            <h3 class="card-title">Total Revenue</h3>
-            <p class="card-description">this month</p>
+        <div class="dashboard-kpi-card">
+            <div class="kpi-header">
+                <span class="kpi-title">Total Revenue</span>
+                <div class="kpi-icon revenue"><img draggable="false" role="img" class="emoji" alt="💰" src="https://s.w.org/images/core/emoji/16.0.1/svg/1f4b0.svg"></div>
+            </div>
+            <div class="kpi-value" id="total-revenue-value">--</div>
         </div>
-        <div class="card-content">
-            <i data-feather="dollar-sign"></i>
-            <p class="text-2xl font-bold" id="total-revenue-value">--</p>
-        </div>
-    </div>
 
-    <div class="dashboard-kpi-card widget-span-3">
-        <div class="card-header">
-            <h3 class="card-title">This Month</h3>
-            <p class="card-description">this week, today</p>
+        <div class="dashboard-kpi-card">
+            <div class="kpi-header">
+                <span class="kpi-title">Revenue Breakdown</span>
+                 <div class="kpi-icon upcoming"><img draggable="false" role="img" class="emoji" alt="⏰" src="https://s.w.org/images/core/emoji/16.0.1/svg/23f0.svg"></div>
+            </div>
+            <div class="kpi-value" id="revenue-breakdown-value">--</div>
         </div>
-        <div class="card-content">
-            <i data-feather="bar-chart-2"></i>
-            <p class="text-2xl font-bold" id="revenue-breakdown-value">--</p>
-        </div>
-    </div>
 
-    <div class="dashboard-kpi-card widget-span-3">
-        <div class="card-header">
-            <h3 class="card-title">Completion Rate</h3>
-            <p class="card-description">completed</p>
-        </div>
-        <div class="card-content">
-            <i data-feather="check-circle"></i>
-            <p class="text-2xl font-bold" id="completion-rate-value">--</p>
+        <div class="dashboard-kpi-card">
+            <div class="kpi-header">
+                <span class="kpi-title">Completion Rate</span>
+                 <div class="kpi-icon upcoming"><img draggable="false" role="img" class="emoji" alt="✅" src="https://s.w.org/images/core/emoji/16.0.1/svg/2705.svg"></div>
+            </div>
+            <div class="kpi-value" id="completion-rate-value">--</div>
         </div>
     </div>
 
@@ -169,7 +159,4 @@ var mobooking_overview_params = {
         error: '<?php esc_html_e('Error loading data', 'mobooking'); ?>'
     }
 };
-</script>
-<script>
-    feather.replace();
 </script>

--- a/header.php
+++ b/header.php
@@ -12,7 +12,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="profile" href="https://gmpg.org/xfn/11">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/feather-icons/4.29.2/feather.min.js"></script>
     <?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>


### PR DESCRIPTION
This commit updates the dashboard overview page's KPI cards to match a specific HTML structure provided by you.

- Wraps the KPI cards in a `dashboard-kpi-grid` container.
- Updates the HTML of each KPI card to use `kpi-header`, `kpi-title`, `kpi-icon`, and `kpi-value` classes.
- Replaces the Feather SVG icons with `<img>` tags pointing to the specified SVG icon URLs.
- Updates the CSS in `dashboard-overview-refactored.css` to match the new HTML structure.
- Removes the Feather Icons script from the theme header as it is no longer needed.