### PR TITLE
Feat: Replace tables with responsive component

### DIFF
--- a/assets/css/dashboard-tables-refactored.css
+++ b/assets/css/dashboard-tables-refactored.css
@@ -1,0 +1,66 @@
+/* ==========================================================================
+   Refactored Dashboard Tables - Shadcn UI Inspired
+   ========================================================================== */
+
+.mobooking-table {
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.mobooking-table-header {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    background-color: hsl(var(--muted));
+    font-weight: 500;
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.mobooking-table-row {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.mobooking-table-row:last-child {
+    border-bottom: none;
+}
+
+.mobooking-table-cell {
+    padding: 1rem;
+    display: flex;
+    align-items: center;
+}
+
+.mobooking-table-cell[data-label] {
+    display: none; /* Hide on desktop */
+}
+
+@media (max-width: 768px) {
+    .mobooking-table-header {
+        display: none;
+    }
+
+    .mobooking-table-row {
+        grid-template-columns: 1fr;
+        padding: 1rem;
+    }
+
+    .mobooking-table-cell {
+        display: flex;
+        justify-content: space-between;
+        padding: 0.5rem 0;
+    }
+
+    .mobooking-table-cell[data-label]::before {
+        content: attr(data-label);
+        font-weight: 500;
+        margin-right: 1rem;
+    }
+
+    .mobooking-table-cell[data-label] {
+        display: flex; /* Show on mobile */
+    }
+}

--- a/assets/js/dashboard-bookings.js
+++ b/assets/js/dashboard-bookings.js
@@ -26,14 +26,6 @@ jQuery(document).ready(function($) {
         return temp.innerHTML;
     }
 
-    function renderTemplate(templateHtml, data) {
-        let template = templateHtml;
-        for (const key in data) {
-            const value = (typeof data[key] === 'string' || typeof data[key] === 'number') ? data[key] : '';
-            template = template.replace(new RegExp('<%=\\s*' + key + '\\s*%>', 'g'), sanitizeHTML(String(value)));
-        }
-        return template;
-    }
 
     function loadBookings(page = 1) {
         currentFilters.paged = page;
@@ -86,11 +78,27 @@ jQuery(document).ready(function($) {
                         // are directly available on `booking` or added to `bookingDataForTemplate`.
                         // `created_at_formatted` is no longer in the table template.
 
-                        bookingsListContainer.find('tbody').append(renderTemplate(bookingItemTemplate, bookingDataForTemplate));
+                        const tableBody = bookingsListContainer.find('.mobooking-table-body');
+                        if(tableBody.length === 0) {
+                            bookingsListContainer.html('<div class="mobooking-table"><div class="mobooking-table-body"></div></div>');
+                        }
+                        tableBody.append(bookingItemTemplate.replace(/<%= booking_id %>/g, booking.booking_id)
+                            .replace(/<%= booking_reference %>/g, booking.booking_reference)
+                            .replace(/<%= customer_name %>/g, booking.customer_name)
+                            .replace(/<%= customer_email %>/g, booking.customer_email)
+                            .replace(/<%= booking_date_formatted %>/g, bookingDataForTemplate.booking_date_formatted)
+                            .replace(/<%= booking_time_formatted %>/g, bookingDataForTemplate.booking_time_formatted)
+                            .replace(/<%= assigned_staff_name %>/g, booking.assigned_staff_name || 'Unassigned')
+                            .replace(/<%= total_price_formatted %>/g, bookingDataForTemplate.total_price_formatted)
+                            .replace(/<%= status %>/g, booking.status)
+                            .replace(/<%= status_display %>/g, bookingDataForTemplate.status_display)
+                            .replace(/<%= icon_html %>/g, '') // Icons are now in the CSS
+                            .replace(/<%= details_page_url %>/g, bookingDataForTemplate.details_page_url)
+                        );
                     });
                     renderPagination(response.data.total_count, response.data.per_page, response.data.current_page);
                 } else if (response.success) {
-                    bookingsListContainer.html('<p>' + (mobooking_bookings_params.i18n.no_bookings_found || 'No bookings found.') + '</p>');
+                    bookingsListContainer.html('<div class="mobooking-table"><div class="mobooking-table-body"><div class="mobooking-table-row no-items"><div class="mobooking-table-cell" colspan="7">' + (mobooking_bookings_params.i18n.no_bookings_found || 'No bookings found.') + '</div></div></div></div>');
                 } else {
                     bookingsListContainer.html('<p>' + (response.data.message || mobooking_bookings_params.i18n.error_loading_bookings || 'Error loading bookings.') + '</p>');
                 }

--- a/dashboard/page-bookings.php
+++ b/dashboard/page-bookings.php
@@ -107,18 +107,17 @@ if ($current_user_id) {
     $bookings_result = $bookings_manager->get_bookings_by_tenant($current_user_id, $default_args);
 
     if (!empty($bookings_result['bookings'])) {
-        $initial_bookings_html .= '<div class="mobooking-table-responsive-wrapper">';
-        $initial_bookings_html .= '<table class="mobooking-table wp-list-table widefat fixed striped">';
-        $initial_bookings_html .= '<thead><tr>';
-        $initial_bookings_html .= '<th>' . esc_html__('Ref', 'mobooking') . '</th>';
-        $initial_bookings_html .= '<th>' . esc_html__('Customer', 'mobooking') . '</th>';
-        $initial_bookings_html .= '<th>' . esc_html__('Booked Date', 'mobooking') . '</th>';
-        $initial_bookings_html .= '<th>' . esc_html__('Assigned Staff', 'mobooking') . '</th>'; // New Column
-        $initial_bookings_html .= '<th>' . esc_html__('Total', 'mobooking') . '</th>';
-        $initial_bookings_html .= '<th>' . esc_html__('Status', 'mobooking') . '</th>';
-        $initial_bookings_html .= '<th>' . esc_html__('Actions', 'mobooking') . '</th>';
-        $initial_bookings_html .= '</tr></thead>';
-        $initial_bookings_html .= '<tbody>';
+        $initial_bookings_html .= '<div class="mobooking-table">';
+        $initial_bookings_html .= '<div class="mobooking-table-header">';
+        $initial_bookings_html .= '<div class="mobooking-table-cell">' . esc_html__('Ref', 'mobooking') . '</div>';
+        $initial_bookings_html .= '<div class="mobooking-table-cell">' . esc_html__('Customer', 'mobooking') . '</div>';
+        $initial_bookings_html .= '<div class="mobooking-table-cell">' . esc_html__('Booked Date', 'mobooking') . '</div>';
+        $initial_bookings_html .= '<div class="mobooking-table-cell">' . esc_html__('Assigned Staff', 'mobooking') . '</div>';
+        $initial_bookings_html .= '<div class="mobooking-table-cell">' . esc_html__('Total', 'mobooking') . '</div>';
+        $initial_bookings_html .= '<div class="mobooking-table-cell">' . esc_html__('Status', 'mobooking') . '</div>';
+        $initial_bookings_html .= '<div class="mobooking-table-cell">' . esc_html__('Actions', 'mobooking') . '</div>';
+        $initial_bookings_html .= '</div>';
+        $initial_bookings_html .= '<div class="mobooking-table-body">';
 
         foreach ($bookings_result['bookings'] as $booking) {
             $status_val = $booking['status'];
@@ -132,24 +131,21 @@ if ($current_user_id) {
 
             $details_page_url = home_url('/dashboard/bookings/?action=view_booking&booking_id=' . $booking['booking_id']);
 
-            $initial_bookings_html .= '<tr data-booking-id="' . esc_attr($booking['booking_id']) . '">';
-            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Ref', 'mobooking') . '">' . esc_html($booking['booking_reference']) . '</td>';
-            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Customer', 'mobooking') . '">' . esc_html($booking['customer_name']) . '<br><small>' . esc_html($booking['customer_email']) . '</small></td>';
-            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Booked Date', 'mobooking') . '">' . esc_html($booking_date_formatted . ' ' . $booking_time_formatted) . '</td>';
-            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Assigned Staff', 'mobooking') . '">' . $assigned_staff_name . '</td>'; // New Column Data
-            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Total', 'mobooking') . '">' . $total_price_formatted . '</td>';
-            // Updated status badge HTML
-            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Status', 'mobooking') . '"><span class="status-badge status-' . esc_attr($status_val) . '">' . $status_icon_html . '<span class="status-text">' . esc_html($status_display) . '</span></span></td>';
-            $initial_bookings_html .= '<td data-colname="' . esc_attr__('Actions', 'mobooking') . '" class="mobooking-table-actions">';
+            $initial_bookings_html .= '<div class="mobooking-table-row" data-booking-id="' . esc_attr($booking['booking_id']) . '">';
+            $initial_bookings_html .= '<div class="mobooking-table-cell" data-label="' . esc_attr__('Ref', 'mobooking') . '">' . esc_html($booking['booking_reference']) . '</div>';
+            $initial_bookings_html .= '<div class="mobooking-table-cell" data-label="' . esc_attr__('Customer', 'mobooking') . '">' . esc_html($booking['customer_name']) . '<br><small>' . esc_html($booking['customer_email']) . '</small></div>';
+            $initial_bookings_html .= '<div class="mobooking-table-cell" data-label="' . esc_attr__('Booked Date', 'mobooking') . '">' . esc_html($booking_date_formatted . ' ' . $booking_time_formatted) . '</div>';
+            $initial_bookings_html .= '<div class="mobooking-table-cell" data-label="' . esc_attr__('Assigned Staff', 'mobooking') . '">' . $assigned_staff_name . '</div>';
+            $initial_bookings_html .= '<div class="mobooking-table-cell" data-label="' . esc_attr__('Total', 'mobooking') . '">' . $total_price_formatted . '</div>';
+            $initial_bookings_html .= '<div class="mobooking-table-cell" data-label="' . esc_attr__('Status', 'mobooking') . '"><span class="status-badge status-' . esc_attr($status_val) . '">' . $status_icon_html . '<span class="status-text">' . esc_html($status_display) . '</span></span></div>';
+            $initial_bookings_html .= '<div class="mobooking-table-cell" data-label="' . esc_attr__('Actions', 'mobooking') . '">';
             $initial_bookings_html .= '<a href="' . esc_url($details_page_url) . '" class="button button-small">' . __('View Details', 'mobooking') . '</a> ';
-            // Only show delete for owner, not worker
             if (class_exists('MoBooking\Classes\Auth') && !\MoBooking\Classes\Auth::is_user_worker($current_user_id)) {
                 $initial_bookings_html .= '<button class="button button-small mobooking-delete-booking-btn" data-booking-id="' . esc_attr($booking['booking_id']) . '">' . __('Delete', 'mobooking') . '</button>';
             }
-            $initial_bookings_html .= '</td></tr>';
+            $initial_bookings_html .= '</div></div>';
         }
-        $initial_bookings_html .= '</tbody></table>';
-        $initial_bookings_html .= '</div>';
+        $initial_bookings_html .= '</div></div>';
     } else {
         $initial_bookings_html = '<p>' . __('No bookings found.', 'mobooking') . '</p>';
     }
@@ -359,24 +355,24 @@ $booking_statuses = [
     </div>
 
 <script type="text/template" id="mobooking-booking-item-template">
-    <tr data-booking-id="<%= booking_id %>">
-        <td data-colname="<?php esc_attr_e('Ref', 'mobooking'); ?>"><%= booking_reference %></td>
-        <td data-colname="<?php esc_attr_e('Customer', 'mobooking'); ?>"><%= customer_name %><br><small><%= customer_email %></small></td>
-        <td data-colname="<?php esc_attr_e('Booked Date', 'mobooking'); ?>"><%= booking_date_formatted %> <%= booking_time_formatted %></td>
-        <td data-colname="<?php esc_attr_e('Assigned Staff', 'mobooking'); ?>"><%= assigned_staff_name || '<?php echo esc_js(__('Unassigned', 'mobooking')); ?>' %></td>
-        <td data-colname="<?php esc_attr_e('Total', 'mobooking'); ?>"><%= total_price_formatted %></td>
-        <td data-colname="<?php esc_attr_e('Status', 'mobooking'); ?>">
+    <div class="mobooking-table-row" data-booking-id="<%= booking_id %>">
+        <div class="mobooking-table-cell" data-label="<?php esc_attr_e('Ref', 'mobooking'); ?>"><%= booking_reference %></div>
+        <div class="mobooking-table-cell" data-label="<?php esc_attr_e('Customer', 'mobooking'); ?>"><%= customer_name %><br><small><%= customer_email %></small></div>
+        <div class="mobooking-table-cell" data-label="<?php esc_attr_e('Booked Date', 'mobooking'); ?>"><%= booking_date_formatted %> <%= booking_time_formatted %></div>
+        <div class="mobooking-table-cell" data-label="<?php esc_attr_e('Assigned Staff', 'mobooking'); ?>"><%= assigned_staff_name || '<?php echo esc_js(__('Unassigned', 'mobooking')); ?>' %></div>
+        <div class="mobooking-table-cell" data-label="<?php esc_attr_e('Total', 'mobooking'); ?>"><%= total_price_formatted %></div>
+        <div class="mobooking-table-cell" data-label="<?php esc_attr_e('Status', 'mobooking'); ?>">
             <span class="status-badge status-<%= status %>">
                 <%= icon_html %> <span class="status-text"><%= status_display %></span>
             </span>
-        </td>
-        <td data-colname="<?php esc_attr_e('Actions', 'mobooking'); ?>" class="mobooking-table-actions">
+        </div>
+        <div class="mobooking-table-cell" data-label="<?php esc_attr_e('Actions', 'mobooking'); ?>">
             <a href="<%= details_page_url %>" class="button button-small"><?php esc_html_e('View Details', 'mobooking'); ?></a>
             <% if (typeof mobooking_dashboard_params !== 'undefined' && mobooking_dashboard_params.currentUserCanDeleteBookings) { %>
                 <button class="button button-small mobooking-delete-booking-btn" data-booking-id="<%= booking_id %>"><?php esc_html_e('Delete', 'mobooking'); ?></button>
             <% } %>
-        </td>
-    </tr>
+        </div>
+    </div>
 </script>
 
 </div>

--- a/dashboard/page-customers.php
+++ b/dashboard/page-customers.php
@@ -135,71 +135,63 @@ $kpi_data = $customers_manager->get_kpi_data( $tenant_id );
             </form>
         </div>
     </div>
-    <div class="mobooking-table-responsive-wrapper">
-    <table class="mobooking-table wp-list-table widefat fixed striped mobooking-customers-table">
-        <thead>
-            <tr>
-                <?php
-                $columns = [
-                    'full_name' => __( 'Full Name', 'mobooking' ),
-                    'email' => __( 'Email', 'mobooking' ),
-                    'phone_number' => __( 'Phone Number', 'mobooking' ),
-                    'total_bookings' => __( 'Total Bookings', 'mobooking' ),
-                    'last_booking_date' => __( 'Last Booking Date', 'mobooking' ),
-                    'status' => __( 'Status', 'mobooking' ),
-                    'actions' => __( 'Actions', 'mobooking' ),
-                ];
+    <div class="mobooking-table">
+        <div class="mobooking-table-header">
+            <?php
+            $columns = [
+                'full_name' => __( 'Full Name', 'mobooking' ),
+                'email' => __( 'Email', 'mobooking' ),
+                'phone_number' => __( 'Phone Number', 'mobooking' ),
+                'total_bookings' => __( 'Total Bookings', 'mobooking' ),
+                'last_booking_date' => __( 'Last Booking Date', 'mobooking' ),
+                'status' => __( 'Status', 'mobooking' ),
+                'actions' => __( 'Actions', 'mobooking' ),
+            ];
 
-                foreach ( $columns as $key => $title ) {
-                    $class = "manage-column column-{$key}";
-                    if ( in_array( $key, [ 'full_name', 'email', 'total_bookings', 'last_booking_date', 'status' ] ) ) {
-                        $order = ( $sort_by === $key && $sort_order === 'ASC' ) ? 'DESC' : 'ASC';
-                        $url = add_query_arg( [ 'orderby' => $key, 'order' => $order ] );
-                        echo "<th scope='col' class='{$class} sortable " . ( $sort_by === $key ? strtolower( $sort_order ) : '' ) . "'>
-                                <a href='" . esc_url( $url ) . "'>
-                                    <span>{$title}</span>
-                                    <span class='sorting-indicator'></span>
-                                </a>
-                              </th>";
-                    } else {
-                        echo "<th scope='col' class='{$class}'>{$title}</th>";
-                    }
+            foreach ( $columns as $key => $title ) {
+                if ( in_array( $key, [ 'full_name', 'email', 'total_bookings', 'last_booking_date', 'status' ] ) ) {
+                    $order = ( $sort_by === $key && $sort_order === 'ASC' ) ? 'DESC' : 'ASC';
+                    $url = add_query_arg( [ 'orderby' => $key, 'order' => $order ] );
+                    echo "<div class='mobooking-table-cell sortable " . ( $sort_by === $key ? strtolower( $sort_order ) : '' ) . "'>
+                            <a href='" . esc_url( $url ) . "'>
+                                <span>{$title}</span>
+                                <span class='sorting-indicator'></span>
+                            </a>
+                          </div>";
+                } else {
+                    echo "<div class='mobooking-table-cell'>{$title}</div>";
                 }
-                ?>
-            </tr>
-        </thead>
-        <tbody id="the-list">
+            }
+            ?>
+        </div>
+        <div class="mobooking-table-body">
             <?php if ( ! empty( $customers ) ) : ?>
                 <?php foreach ( $customers as $customer ) : ?>
-                    <tr id="customer-<?php echo $customer->id; ?>">
-                        <td data-label="<?php esc_attr_e( 'Full Name', 'mobooking' ); ?>"><?php echo esc_html( $customer->full_name ); ?></td>
-                        <td data-label="<?php esc_attr_e( 'Email', 'mobooking' ); ?>"><?php echo esc_html( $customer->email ); ?></td>
-                        <td data-label="<?php esc_attr_e( 'Phone Number', 'mobooking' ); ?>"><?php echo esc_html( $customer->phone_number ); ?></td>
-                        <td data-label="<?php esc_attr_e( 'Total Bookings', 'mobooking' ); ?>"><?php echo esc_html( $customer->total_bookings ); ?></td>
-                        <td data-label="<?php esc_attr_e( 'Last Booking Date', 'mobooking' ); ?>"><?php echo esc_html( $customer->last_booking_date ? date_i18n( get_option( 'date_format' ), strtotime( $customer->last_booking_date ) ) : __( 'N/A', 'mobooking' ) ); ?></td>
-                        <td data-label="<?php esc_attr_e( 'Status', 'mobooking' ); ?>">
+                    <div class="mobooking-table-row" id="customer-<?php echo $customer->id; ?>">
+                        <div class="mobooking-table-cell" data-label="<?php esc_attr_e( 'Full Name', 'mobooking' ); ?>"><?php echo esc_html( $customer->full_name ); ?></div>
+                        <div class="mobooking-table-cell" data-label="<?php esc_attr_e( 'Email', 'mobooking' ); ?>"><?php echo esc_html( $customer->email ); ?></div>
+                        <div class="mobooking-table-cell" data-label="<?php esc_attr_e( 'Phone Number', 'mobooking' ); ?>"><?php echo esc_html( $customer->phone_number ); ?></div>
+                        <div class="mobooking-table-cell" data-label="<?php esc_attr_e( 'Total Bookings', 'mobooking' ); ?>"><?php echo esc_html( $customer->total_bookings ); ?></div>
+                        <div class="mobooking-table-cell" data-label="<?php esc_attr_e( 'Last Booking Date', 'mobooking' ); ?>"><?php echo esc_html( $customer->last_booking_date ? date_i18n( get_option( 'date_format' ), strtotime( $customer->last_booking_date ) ) : __( 'N/A', 'mobooking' ) ); ?></div>
+                        <div class="mobooking-table-cell" data-label="<?php esc_attr_e( 'Status', 'mobooking' ); ?>">
                             <span class="status-badge status-<?php echo esc_attr( $customer->status ); ?>">
                                 <?php echo mobooking_get_customer_status_badge_icon_svg( $customer->status ); ?>
                                 <span class="status-text"><?php echo esc_html( ucfirst( $customer->status ) ); ?></span>
                             </span>
-                        </td>
-                        <td data-label="<?php esc_attr_e( 'Actions', 'mobooking' ); ?>">
+                        </div>
+                        <div class="mobooking-table-cell" data-label="<?php esc_attr_e( 'Actions', 'mobooking' ); ?>">
                             <a href="<?php echo esc_url( home_url( '/dashboard/customer-details/?customer_id=' . $customer->id ) ); ?>" class="button">
                                 <?php esc_html_e( 'View Details', 'mobooking' ); ?>
                             </a>
-                        </td>
-                    </tr>
+                        </div>
+                    </div>
                 <?php endforeach; ?>
             <?php else : ?>
-                <tr class="no-items">
-                    <td class="colspanchange" colspan="7"><?php esc_html_e( 'No customers found.', 'mobooking' ); ?></td>
-                </tr>
+                <div class="mobooking-table-row no-items">
+                    <div class="mobooking-table-cell" colspan="7"><?php esc_html_e( 'No customers found.', 'mobooking' ); ?></div>
+                </div>
             <?php endif; ?>
-        </tbody>
-    </table>
-
-        </tbody>
-    </table>
+        </div>
     </div>
     <div id="mobooking-customers-pagination-container" class="tablenav bottom">
         <div class="tablenav-pages">

--- a/functions/routing.php
+++ b/functions/routing.php
@@ -124,6 +124,7 @@ function mobooking_enqueue_dashboard_scripts($current_page_slug = '') {
 
     // Specific to Bookings page
     if ($current_page_slug === 'bookings') {
+        wp_enqueue_style('mobooking-dashboard-tables-refactored', MOBOOKING_THEME_URI . 'assets/css/dashboard-tables-refactored.css', array(), MOBOOKING_VERSION);
         wp_enqueue_script('jquery-ui-datepicker');
         wp_enqueue_script('mobooking-dashboard-bookings', MOBOOKING_THEME_URI . 'assets/js/dashboard-bookings.js', array('jquery', 'jquery-ui-datepicker'), MOBOOKING_VERSION, true);
         $bookings_params = array_merge($dashboard_params, [
@@ -340,6 +341,7 @@ function mobooking_enqueue_dashboard_scripts($current_page_slug = '') {
 
     // Specific to Customers page
     if ($current_page_slug === 'customers' || $current_page_slug === 'customer-details') {
+        wp_enqueue_style('mobooking-dashboard-tables-refactored', MOBOOKING_THEME_URI . 'assets/css/dashboard-tables-refactored.css', array(), MOBOOKING_VERSION);
         wp_enqueue_style('mobooking-dashboard-customer-details', MOBOOKING_THEME_URI . 'assets/css/dashboard-customer-details.css', array(), MOBOOKING_VERSION);
     }
 


### PR DESCRIPTION
This commit replaces the traditional HTML tables on the bookings and customers pages with a modern, responsive, `div`-based table component inspired by ShadCN UI.

- Replaces the `<table>` element with a `div`-based structure on the bookings and customers pages.
- Creates a new stylesheet `dashboard-tables-refactored.css` with styles for the new table component, including responsive styles for mobile devices.
- Updates the JavaScript on the bookings page to work with the new table structure.
- Enqueues the new stylesheet on the bookings and customers pages.