### PR TITLE
Fix: Correctly add service areas from predefined list

### DIFF
--- a/classes/Areas.php
+++ b/classes/Areas.php
@@ -608,11 +608,9 @@ class Areas {
             return '';
         }
 
-        if (isset($data['countries']) && is_array($data['countries'])) {
-            foreach ($data['countries'] as $country_code => $country_data) {
-                if (isset($country_data['name']) && $country_data['name'] === $country_name) {
-                    return $country_code;
-                }
+        foreach ($data as $country_code => $country_data) {
+            if (isset($country_data['name']) && $country_data['name'] === $country_name) {
+                return $country_code;
             }
         }
 


### PR DESCRIPTION
This commit fixes a bug that prevented cities and service areas from being added correctly from the predefined list in the `service-areas-data.json` file.

- I corrected the `get_country_code_from_name` function in `classes/Areas.php` to correctly parse the JSON data and return the correct country code.
- This ensures that the `add_bulk_areas` function receives the correct data and can add the service areas to the database as expected.