### PR TITLE
feat: Restrict service areas to Sweden only

### DIFF
--- a/assets/js/enhanced-areas.js
+++ b/assets/js/enhanced-areas.js
@@ -17,9 +17,6 @@
   };
 
   // DOM elements
-  const $countrySelector = $("#mobooking-country-selector");
-  const $selectCountryBtn = $("#select-country-btn");
-  const $countrySelectionCard = $("#country-selection-card");
   const $citiesAreasCard = $("#cities-areas-selection-card");
   const $cancelSelectionBtn = $("#cancel-selection-btn");
   const $selectedCountryName = $("#selected-country-name");
@@ -54,7 +51,14 @@
       return;
     }
 
-    loadCountries();
+    // Automatically load Sweden
+    currentCountry = { code: 'SE', name: 'Sweden' };
+    $selectedCountryName.text(currentCountry.name);
+    $citiesAreasCard.show();
+    $areasSelectionSection.hide();
+    $selectionActions.hide();
+    loadCitiesForCountry(currentCountry.code);
+
     loadServiceCoverage();
     bindEvents();
   }
@@ -63,9 +67,6 @@
    * Bind all event handlers
    */
   function bindEvents() {
-    // Country selection
-    $countrySelector.on("change", handleCountrySelectChange);
-    $selectCountryBtn.on("click", handleSelectCountry);
     $cancelSelectionBtn.on("click", handleCancelSelection);
 
     // Cities and areas selection
@@ -102,101 +103,8 @@
     $(document).on("click", ".page-numbers", handlePaginationClick);
   }
 
-  /**
-   * Load available countries
-   */
-  function loadCountries() {
-    $.ajax({
-      url: mobooking_areas_params.ajax_url,
-      type: "POST",
-      data: {
-        action: "mobooking_get_countries",
-        nonce: mobooking_areas_params.nonce,
-      },
-      success: function (response) {
-        if (response.success && response.data?.countries) {
-          populateCountryDropdown(response.data.countries);
-        } else {
-          showFeedback(
-            $selectionFeedback,
-            i18n.error || "Error loading countries",
-            "error"
-          );
-        }
-      },
-      error: function () {
-        showFeedback(
-          $selectionFeedback,
-          i18n.error || "Error loading countries",
-          "error"
-        );
-      },
-    });
-  }
 
-  /**
-   * Populate country dropdown
-   */
-  function populateCountryDropdown(countries) {
-    $countrySelector.empty().append(
-      $("<option>", {
-        value: "",
-        text: i18n.choose_country || "Choose a country to add...",
-      })
-    );
 
-    countries.forEach(function (country) {
-      $countrySelector.append(
-        $("<option>", { value: country.code, text: country.name })
-      );
-    });
-
-    // Also populate filter dropdown
-    $countryFilter.empty().append(
-      $("<option>", {
-        value: "",
-        text: i18n.all_countries || "All Countries",
-      })
-    );
-
-    countries.forEach(function (country) {
-      $countryFilter.append(
-        $("<option>", { value: country.name, text: country.name })
-      );
-    });
-  }
-
-  /**
-   * Handle country selector change
-   */
-  function handleCountrySelectChange() {
-    const selected = $(this).val();
-    $selectCountryBtn.prop("disabled", !selected);
-  }
-
-  /**
-   * Handle select country button click
-   */
-  function handleSelectCountry() {
-    const countryCode = $countrySelector.val();
-    const countryName = $countrySelector.find("option:selected").text();
-
-    if (!countryCode) return;
-
-    currentCountry = { code: countryCode, name: countryName };
-    selectedCities.clear();
-    selectedAreas.clear();
-
-    // Update UI
-    $selectedCountryName.text(countryName);
-    $countrySelectionCard.hide();
-    $citiesAreasCard.show();
-    $areasSelectionSection.hide();
-    $selectionActions.hide();
-
-    // Load cities for selected country
-    loadCitiesForCountry(countryCode);
-  }
 
   /**
    * Handle cancel selection

--- a/dashboard/page-areas.php
+++ b/dashboard/page-areas.php
@@ -29,38 +29,26 @@ $current_user_id = get_current_user_id();
     </div>
 
     <div class="mobooking-dashboard-content">
-        <!-- Country Selection Card -->
-        <div class="mobooking-card" id="country-selection-card">
+        <!-- Country Display Card -->
+        <div class="mobooking-card">
             <div class="mobooking-card-header">
                 <h3 class="mobooking-card-title">
                     <svg class="mobooking-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945"/>
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                     </svg>
-                    <?php esc_html_e('Select Country', 'mobooking'); ?>
+                    <?php esc_html_e('Service Country', 'mobooking'); ?>
                 </h3>
                 <p class="mobooking-card-description">
-                    <?php esc_html_e('Choose a country to add to your service coverage. You can manage multiple countries separately.', 'mobooking'); ?>
+                    <?php esc_html_e('Your service areas are configured for Sweden.', 'mobooking'); ?>
                 </p>
             </div>
-
             <div class="country-selection-form">
                 <div class="mobooking-form-group">
-                    <label for="mobooking-country-selector" class="mobooking-form-label">
-                        <?php esc_html_e('Available Countries', 'mobooking'); ?>
+                    <label class="mobooking-form-label">
+                        <?php esc_html_e('Selected Country', 'mobooking'); ?>
                     </label>
-                    <select id="mobooking-country-selector" class="mobooking-form-select">
-                        <option value=""><?php esc_html_e('Choose a country to add...', 'mobooking'); ?></option>
-                    </select>
-                </div>
-
-                <div class="mobooking-form-actions">
-                    <button type="button" id="select-country-btn" class="mobooking-btn mobooking-btn-primary" disabled>
-                        <svg class="mobooking-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
-                        </svg>
-                        <?php esc_html_e('Add Country', 'mobooking'); ?>
-                    </button>
+                    <div class="static-country-display">Sweden</div>
                 </div>
             </div>
         </div>

--- a/data/service-areas-data.json
+++ b/data/service-areas-data.json
@@ -18,42 +18,5 @@
         {"name": "Gamla Staden", "zip": "21122"}
       ]
     }
-  },
-  "NO": {
-    "name": "Norway",
-    "cities": {
-      "Oslo": [
-        {"name": "Sentrum", "zip": "0150"},
-        {"name": "Grünerløkka", "zip": "0550"},
-        {"name": "Frogner", "zip": "0250"}
-      ],
-      "Bergen": [
-        {"name": "Bryggen", "zip": "5003"},
-        {"name": "Nordnes", "zip": "5005"}
-      ],
-      "Trondheim": [
-        {"name": "Midtbyen", "zip": "7010"},
-        {"name": "Bakklandet", "zip": "7014"}
-      ]
-    }
-  },
-  "DK": {
-    "name": "Denmark",
-    "cities": {
-      "Copenhagen": [
-        {"name": "Indre By", "zip": "1000"},
-        {"name": "Vesterbro", "zip": "1600"},
-        {"name": "Nørrebro", "zip": "2200"},
-        {"name": "Østerbro", "zip": "2100"}
-      ],
-      "Aarhus": [
-        {"name": "Aarhus C", "zip": "8000"},
-        {"name": "Trøjborg", "zip": "8200"}
-      ],
-      "Odense": [
-        {"name": "Odense C", "zip": "5000"},
-        {"name": "Dalum", "zip": "5250"}
-      ]
-    }
   }
 }


### PR DESCRIPTION
This commit updates the service areas functionality to only support Sweden. The country selection UI has been removed, and the application now automatically loads Swedish cities for selection.

The following changes have been made:

- **Data**: The `data/service-areas-data.json` file has been updated to only include data for Sweden.
- **UI**: The `dashboard/page-areas.php` file has been modified to remove the country selection dropdown and button. It now displays "Sweden" as a static text.
- **JavaScript**: The `assets/js/enhanced-areas.js` file has been updated to automatically load the cities for Sweden when the page loads. The code related to country selection has been removed.

These changes simplify the user interface and ensure that the service areas are restricted to Sweden, as per the requirements.