### PR TITLE
feat: Rework Service Areas page with a modal-based workflow

### DIFF
--- a/assets/css/enhanced-areas.css
+++ b/assets/css/enhanced-areas.css
@@ -1,12 +1,175 @@
 /**
  * Enhanced Service Areas CSS
- * Country-based selection with persistent visual management
+ * Swedish-focused, modal-based city and area management
  */
 
-/* ==================== COUNTRY SELECTION ==================== */
+.country-flag-emoji {
+    font-size: 1.5rem;
+    margin-right: 0.5rem;
+    vertical-align: middle;
+}
 
-.country-selection-form {
+.cities-grid-container {
     padding: 1.5rem;
+}
+
+.cities-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.city-card {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 1.5rem;
+    border: 1px solid #e9ecef;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    background-color: #fff;
+}
+
+.city-card:hover {
+    border-color: #007bff;
+    box-shadow: 0 4px 12px rgba(0, 123, 255, 0.1);
+    transform: translateY(-2px);
+}
+
+.city-card .city-name {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #343a40;
+}
+
+.city-card .city-action-link {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: #007bff;
+    transition: color 0.2s ease;
+}
+
+/* Modal Styles */
+.mobooking-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1050;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.mobooking-modal-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    animation: fadeIn 0.3s ease;
+}
+
+.mobooking-modal-content {
+    background-color: #fff;
+    border-radius: 0.75rem;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+    width: 90%;
+    max-width: 600px;
+    z-index: 1051;
+    animation: slideInDown 0.3s ease;
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+}
+
+.mobooking-modal-header {
+    padding: 1.5rem;
+    border-bottom: 1px solid #e9ecef;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.mobooking-modal-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
+    color: #212529;
+}
+
+.mobooking-modal-close-btn {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #6c757d;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+    opacity: 0.7;
+    transition: opacity 0.2s ease;
+}
+
+.mobooking-modal-close-btn:hover {
+    opacity: 1;
+}
+
+.mobooking-modal-body {
+    padding: 1.5rem;
+    overflow-y: auto;
+}
+
+.areas-selection-controls {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.modal-areas-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.modal-area-item {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    border: 1px solid #e9ecef;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.modal-area-item:hover {
+    background-color: #f8f9fa;
+}
+
+.modal-area-item input[type="checkbox"] {
+    margin-right: 0.75rem;
+}
+
+.modal-area-item .area-name {
+    font-weight: 500;
+}
+
+.modal-area-item .area-zip {
+    margin-left: auto;
+    font-size: 0.85rem;
+    color: #6c757d;
+}
+
+.mobooking-modal-footer {
+    padding: 1.5rem;
+    border-top: 1px solid #e9ecef;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 0.75rem;
 }
 
 .country-badge {
@@ -230,6 +393,57 @@
     font-size: 0.9rem;
 }
 
+/* Coverage List Styles */
+.coverage-cities-list {
+    padding: 1rem;
+}
+
+.coverage-city-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    border: 1px solid #e9ecef;
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+    background-color: #fff;
+}
+
+.coverage-city-item .city-info {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.coverage-city-item .city-stats {
+    margin-left: 1rem;
+    font-size: 0.9rem;
+    color: #6c757d;
+}
+
+.coverage-city-item .city-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+/* Animations */
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes slideInDown {
+    from { transform: translateY(-30px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+
+@media (max-width: 768px) {
+    .cities-grid {
+        grid-template-columns: 1fr;
+    }
+    .modal-areas-grid {
+        grid-template-columns: 1fr;
+    }
+}
 /* ==================== SERVICE COVERAGE DISPLAY ==================== */
 
 .service-coverage-container {

--- a/dashboard/page-areas.php
+++ b/dashboard/page-areas.php
@@ -18,96 +18,32 @@ $current_user_id = get_current_user_id();
 <div class="mobooking-dashboard-page">
     <div class="mobooking-page-header">
         <h2 class="mobooking-page-title">
-            <svg class="mobooking-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-            </svg>
-            <?php esc_html_e('Service Areas Management', 'mobooking'); ?>
+            <span class="country-flag-emoji">🇸🇪</span>
+            <?php esc_html_e('Swedish Service Areas', 'mobooking'); ?>
         </h2>
         <p class="mobooking-page-description">
-            <?php esc_html_e('Build your service coverage by selecting countries, then choosing specific cities and areas within them.', 'mobooking'); ?>
+            <?php esc_html_e('Manage your service coverage by selecting cities and their specific areas within Sweden.', 'mobooking'); ?>
         </p>
     </div>
 
     <div class="mobooking-dashboard-content">
-        <!-- Country Display Card -->
+        <!-- City Selection Card -->
         <div class="mobooking-card">
             <div class="mobooking-card-header">
                 <h3 class="mobooking-card-title">
-                    <svg class="mobooking-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945"/>
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                    </svg>
-                    <?php esc_html_e('Service Country', 'mobooking'); ?>
+                    <?php esc_html_e('Select Swedish Cities', 'mobooking'); ?>
                 </h3>
                 <p class="mobooking-card-description">
-                    <?php esc_html_e('Your service areas are configured for Sweden.', 'mobooking'); ?>
+                    <?php esc_html_e('Click on a city to manage its service areas. Areas can be enabled or disabled individually.', 'mobooking'); ?>
                 </p>
             </div>
-            <div class="country-selection-form">
-                <div class="mobooking-form-group">
-                    <label class="mobooking-form-label">
-                        <?php esc_html_e('Selected Country', 'mobooking'); ?>
-                    </label>
-                    <div class="static-country-display">Sweden</div>
+            <div id="cities-grid-container" class="cities-grid-container">
+                <!-- Cities will be loaded here by JavaScript -->
+                <div class="mobooking-loading-state">
+                    <div class="mobooking-spinner"></div>
+                    <p><?php esc_html_e('Loading Swedish cities...', 'mobooking'); ?></p>
                 </div>
             </div>
-        </div>
-
-        <!-- Cities & Areas Selection Card (Initially Hidden) -->
-        <div class="mobooking-card" id="cities-areas-selection-card" style="display: none;">
-            <div class="mobooking-card-header">
-                <div class="selection-header-content">
-                    <div>
-                        <h3 class="mobooking-card-title">
-                            <svg class="mobooking-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
-                            </svg>
-                            <?php esc_html_e('Select Cities & Areas', 'mobooking'); ?>
-                            <span id="selected-country-name" class="country-badge"></span>
-                        </h3>
-                        <p class="mobooking-card-description">
-                            <?php esc_html_e('Choose specific cities and areas within the selected country for your service coverage.', 'mobooking'); ?>
-                        </p>
-                    </div>
-                    <button type="button" id="cancel-selection-btn" class="mobooking-btn mobooking-btn-secondary mobooking-btn-sm">
-                        <?php esc_html_e('Cancel', 'mobooking'); ?>
-                    </button>
-                </div>
-            </div>
-
-            <!-- Cities Selection -->
-            <div class="cities-selection-section">
-                <h4 class="section-title"><?php esc_html_e('Available Cities', 'mobooking'); ?></h4>
-                <div id="cities-grid" class="selection-grid">
-                    <!-- Cities will be loaded here -->
-                </div>
-            </div>
-
-            <!-- Areas Selection (Initially Hidden) -->
-            <div class="areas-selection-section" id="areas-selection-section" style="display: none;">
-                <h4 class="section-title">
-                    <?php esc_html_e('Available Areas in', 'mobooking'); ?> 
-                    <span id="selected-city-name" class="city-badge"></span>
-                </h4>
-                <div id="areas-grid" class="selection-grid">
-                    <!-- Areas will be loaded here -->
-                </div>
-            </div>
-
-            <!-- Action Buttons -->
-            <div class="mobooking-form-actions" id="selection-actions" style="display: none;">
-                <button type="button" id="save-selections-btn" class="mobooking-btn mobooking-btn-success">
-                    <svg class="mobooking-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-                    </svg>
-                    <?php esc_html_e('Save Selected Areas', 'mobooking'); ?>
-                </button>
-                <button type="button" id="back-to-cities-btn" class="mobooking-btn mobooking-btn-secondary" style="display: none;">
-                    <?php esc_html_e('← Back to Cities', 'mobooking'); ?>
-                </button>
-            </div>
-
-            <div id="selection-feedback" class="mobooking-feedback" style="display: none;"></div>
         </div>
 
         <!-- Current Service Coverage -->
@@ -129,19 +65,15 @@ $current_user_id = get_current_user_id();
                 <div class="mobooking-search-filter-row">
                     <div class="mobooking-search-group">
                         <div class="mobooking-search-input-wrapper">
-                            <svg class="mobooking-search-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
-                            </svg>
-                            <input type="text" id="coverage-search" class="mobooking-search-input" placeholder="<?php esc_attr_e('Search countries, cities, areas...', 'mobooking'); ?>">
+                            <input type="text" id="coverage-search" class="mobooking-search-input" placeholder="<?php esc_attr_e('Search cities or areas...', 'mobooking'); ?>">
                         </div>
                     </div>
-
                     <div class="mobooking-filter-group">
-                        <select id="country-filter" class="mobooking-form-select mobooking-form-select-sm">
-                            <option value=""><?php esc_html_e('All Countries', 'mobooking'); ?></option>
+                        <select id="city-filter" class="mobooking-form-select mobooking-form-select-sm">
+                            <option value=""><?php esc_html_e('All Cities', 'mobooking'); ?></option>
                         </select>
                         <select id="status-filter" class="mobooking-form-select mobooking-form-select-sm">
-                            <option value=""><?php esc_html_e('All Status', 'mobooking'); ?></option>
+                            <option value=""><?php esc_html_e('All Statuses', 'mobooking'); ?></option>
                             <option value="active"><?php esc_html_e('Active', 'mobooking'); ?></option>
                             <option value="inactive"><?php esc_html_e('Inactive', 'mobooking'); ?></option>
                         </select>
@@ -176,6 +108,37 @@ $current_user_id = get_current_user_id();
 
             <!-- Pagination -->
             <div id="coverage-pagination" class="mobooking-pagination-container"></div>
+        </div>
+    </div>
+</div>
+
+<!-- Area Selection Modal -->
+<div id="area-selection-modal" class="mobooking-modal" style="display: none;">
+    <div class="mobooking-modal-overlay"></div>
+    <div class="mobooking-modal-content">
+        <div class="mobooking-modal-header">
+            <h4 class="mobooking-modal-title">
+                <?php esc_html_e('Select Areas for', 'mobooking'); ?> <span id="modal-city-name"></span>
+            </h4>
+            <button type="button" class="mobooking-modal-close-btn">&times;</button>
+        </div>
+        <div class="mobooking-modal-body">
+            <div class="areas-selection-controls">
+                <button type="button" id="modal-select-all" class="mobooking-btn-link"><?php esc_html_e('Select All', 'mobooking'); ?></button>
+                <button type="button" id="modal-deselect-all" class="mobooking-btn-link"><?php esc_html_e('Deselect All', 'mobooking'); ?></button>
+            </div>
+            <div id="modal-areas-grid" class="modal-areas-grid">
+                <!-- Areas for the selected city will be loaded here -->
+            </div>
+        </div>
+        <div class="mobooking-modal-footer">
+            <div id="modal-feedback" class="mobooking-feedback" style="display: none;"></div>
+            <button type="button" id="modal-cancel-btn" class="mobooking-btn mobooking-btn-secondary">
+                <?php esc_html_e('Cancel', 'mobooking'); ?>
+            </button>
+            <button type="button" id="modal-save-btn" class="mobooking-btn mobooking-btn-primary">
+                <?php esc_html_e('Save Areas', 'mobooking'); ?>
+            </button>
         </div>
     </div>
 </div>
@@ -237,6 +200,20 @@ wp_localize_script('mobooking-enhanced-areas', 'mobooking_areas_params', [
     'ajax_url' => admin_url('admin-ajax.php'),
     'nonce' => wp_create_nonce('mobooking_dashboard_nonce'),
     'user_id' => $current_user_id,
+    'country_code' => 'SE', // Hardcode Sweden
+    'i18n' => [
+        'loading_cities' => __('Loading Swedish cities...', 'mobooking'),
+        'loading_areas' => __('Loading areas...', 'mobooking'),
+        'no_cities_available' => __('No cities available to configure.', 'mobooking'),
+        'no_areas_available' => __('No areas found for this city.', 'mobooking'),
+        'save_areas' => __('Save Areas', 'mobooking'),
+        'saving' => __('Saving...', 'mobooking'),
+        'areas_saved_success' => __('Service areas for %s have been updated.', 'mobooking'),
+        'error_saving' => __('An error occurred while saving. Please try again.', 'mobooking'),
+        'confirm_remove_city' => __('Are you sure you want to remove all service areas for %s? This cannot be undone.', 'mobooking'),
+        'city_removed_success' => __('All service areas for %s have been removed.', 'mobooking'),
+        'error_removing_city' => __('Failed to remove city. Please try again.', 'mobooking'),
+    ],
 ]);
 ?>
 <?php


### PR DESCRIPTION
This commit completely refactors the Service Areas page to introduce a more streamlined, Swedish-focused, and user-friendly experience. The new design is centered around a modal-based workflow for managing service areas on a per-city basis.

The following changes have been made:

- **UI/UX Rework**: The old city and area selection cards have been replaced with a new interface where clicking on a city opens a modal window to manage its service areas. This simplifies the workflow and provides a more intuitive user experience.
- **Swedish-First Design**: The page is now explicitly branded for Swedish service areas, with a Swedish flag emoji in the header and updated terminology.
- **Per-City Management**: You can now manage service areas for each city individually. This includes saving areas on a per-city basis and viewing the coverage grouped by city.
- **Updated Filtering**: The coverage section now features a "City" filter instead of a "Country" filter, which is more relevant to the new workflow.
- **Code Refactoring**: The HTML, JavaScript, and CSS for the Service Areas page have been extensively refactored to support the new design and functionality.