### PR TITLE
fix: Resolve JavaScript and AJAX errors in invitation flow

### DIFF
--- a/assets/js/dashboard-workers.js
+++ b/assets/js/dashboard-workers.js
@@ -457,7 +457,8 @@
      * Form validation
      */
     validateInviteForm: function ($form) {
-      var email = $form.find("#invite_email").val().trim();
+      var emailValue = $form.find("#invite_email").val();
+      var email = emailValue ? emailValue.trim() : "";
       var role = $form.find("#invite_role").val();
 
       if (!email) {

--- a/classes/Auth.php
+++ b/classes/Auth.php
@@ -467,22 +467,8 @@ class Auth {
         $inviter_user_data = get_userdata($current_user_id);
         $inviter_name = $inviter_user_data ? $inviter_user_data->display_name : get_bloginfo('name');
 
-        $subject = sprintf( __( 'You have been invited to %s', 'mobooking' ), get_bloginfo( 'name' ) );
-
-        $role_display_name = ucfirst( str_replace( 'mobooking_worker_', '', $assigned_role ) );
-
-        $body_content = '<h2>' . __( 'You\'re Invited!', 'mobooking' ) . '</h2>';
-        $body_content .= '<p>' . sprintf( __( 'Hi %s,', 'mobooking' ), $worker_email ) . '</p>';
-        $body_content .= '<p>' . sprintf( __( 'You have been invited to join %s as a %s by %s.', 'mobooking' ), '<strong>' . get_bloginfo( 'name' ) . '</strong>', '<strong>' . $role_display_name . '</strong>', '<strong>' . $inviter_name . '</strong>' ) . '</p>';
-        $body_content .= '<p>' . __( 'To accept this invitation and complete your registration, please click the button below. This link is valid for 7 days.', 'mobooking' ) . '</p>';
-        $body_content .= '<p style="text-align:center; margin-top: 24px;"><a href="' . esc_url( $registration_link ) . '" class="button">' . __( 'Accept Invitation & Register', 'mobooking' ) . '</a></p>';
-        $body_content .= '<p style="font-size: 12px; color: #718096;">' . __( 'If you were not expecting this invitation, please ignore this email.', 'mobooking' ) . '</p>';
-
         $notifications = new Notifications();
-        $full_email_html = $notifications->get_styled_email_html($subject, get_bloginfo('name'), $body_content);
-
-        $headers = ['Content-Type: text/html; charset=UTF-8'];
-        $sent = wp_mail( $worker_email, $subject, $full_email_html, $headers );
+        $sent = $notifications->send_invitation_email($worker_email, $assigned_role, $inviter_name, $registration_link);
 
         if ( $sent ) {
             wp_send_json_success( array( 'message' => __( 'Invitation sent successfully to ', 'mobooking' ) . $worker_email ) );
@@ -803,31 +789,8 @@ public function handle_ajax_registration() {
      */
     private function send_welcome_email( $user_id, $display_name ) {
         try {
-            $user_info = get_userdata( $user_id );
-            $user_email = $user_info->user_email;
-
-            $subject = sprintf( 
-                __( 'Welcome to %s, %s!', 'mobooking' ), 
-                get_bloginfo( 'name' ), 
-                $display_name 
-            );
-
-            $body_content = '<h2>' . sprintf(__( 'Welcome, %s!', 'mobooking' ), $display_name) . '</h2>';
-            $body_content .= '<p>' . sprintf( __( 'Thank you for registering with %s. We are excited to have you on board!', 'mobooking' ), get_bloginfo( 'name' ) ) . '</p>';
-            $body_content .= '<p>' . __( 'You can access your dashboard to get started managing your business and bookings.', 'mobooking' ) . '</p>';
-            $body_content .= '<p style="text-align:center; margin-top: 24px;"><a href="' . esc_url( home_url( '/dashboard/' ) ) . '" class="button">' . __( 'Go to Your Dashboard', 'mobooking' ) . '</a></p>';
-            $body_content .= '<p>' . __( 'If you have any questions, feel free to contact our support team.', 'mobooking' ) . '</p>';
-
             $notifications = new Notifications();
-            $full_email_html = $notifications->get_styled_email_html($subject, get_bloginfo('name'), $body_content);
-
-            $headers = ['Content-Type: text/html; charset=UTF-8'];
-            $email_sent = wp_mail( $user_email, $subject, $full_email_html, $headers );
-            
-            if ( !$email_sent ) {
-                error_log( 'MoBooking: Failed to send welcome email to ' . $user_email );
-            }
-
+            $notifications->send_welcome_email($user_id, $display_name);
         } catch ( Exception $e ) {
             error_log( 'MoBooking: Welcome email error - ' . $e->getMessage() );
         }

--- a/classes/Notifications.php
+++ b/classes/Notifications.php
@@ -431,4 +431,63 @@ class Notifications {
         }
         return $email_sent;
     }
+
+    /**
+     * Sends a welcome email to a new business owner.
+     * @param int $user_id The ID of the new user.
+     * @param string $display_name The display name of the new user.
+     * @return bool
+     */
+    public function send_welcome_email(int $user_id, string $display_name): bool {
+        $user_info = get_userdata($user_id);
+        if (!$user_info) {
+            return false;
+        }
+        $user_email = $user_info->user_email;
+
+        $subject = sprintf(__('Welcome to %s, %s!', 'mobooking'), get_bloginfo('name'), $display_name);
+
+        $body_content = '<h2>' . sprintf(__('Welcome, %s!', 'mobooking'), $display_name) . '</h2>';
+        $body_content .= '<p>' . sprintf(__('Thank you for registering with %s. We are excited to have you on board!', 'mobooking'), get_bloginfo('name')) . '</p>';
+        $body_content .= '<p>' . __('You can access your dashboard to get started managing your business and bookings.', 'mobooking') . '</p>';
+        $body_content .= '<p style="text-align:center; margin-top: 24px;"><a href="' . esc_url(home_url('/dashboard/')) . '" class="button">' . __('Go to Your Dashboard', 'mobooking') . '</a></p>';
+        $body_content .= '<p>' . __('If you have any questions, feel free to contact our support team.', 'mobooking') . '</p>';
+
+        $full_email_html = $this->get_styled_email_html($subject, get_bloginfo('name'), $body_content);
+
+        $headers = $this->get_email_headers();
+        $email_sent = wp_mail($user_email, $subject, $full_email_html, $headers);
+
+        if (!$email_sent) {
+            error_log('MoBooking: Failed to send welcome email to ' . $user_email);
+        }
+
+        return $email_sent;
+    }
+
+    /**
+     * Sends an invitation email to a new worker.
+     * @param string $worker_email The email of the worker to invite.
+     * @param string $assigned_role The role assigned to the worker.
+     * @param string $inviter_name The name of the person inviting the worker.
+     * @param string $registration_link The link to the registration page.
+     * @return bool
+     */
+    public function send_invitation_email(string $worker_email, string $assigned_role, string $inviter_name, string $registration_link): bool {
+        $subject = sprintf(__('You have been invited to %s', 'mobooking'), get_bloginfo('name'));
+
+        $role_display_name = ucfirst(str_replace('mobooking_worker_', '', $assigned_role));
+
+        $body_content = '<h2>' . __('You\'re Invited!', 'mobooking') . '</h2>';
+        $body_content .= '<p>' . sprintf(__('Hi %s,', 'mobooking'), $worker_email) . '</p>';
+        $body_content .= '<p>' . sprintf(__('You have been invited to join %s as a %s by %s.', 'mobooking'), '<strong>' . get_bloginfo('name') . '</strong>', '<strong>' . $role_display_name . '</strong>', '<strong>' . $inviter_name . '</strong>') . '</p>';
+        $body_content .= '<p>' . __('To accept this invitation and complete your registration, please click the button below. This link is valid for 7 days.', 'mobooking') . '</p>';
+        $body_content .= '<p style="text-align:center; margin-top: 24px;"><a href="' . esc_url($registration_link) . '" class="button">' . __('Accept Invitation & Register', 'mobooking') . '</a></p>';
+        $body_content .= '<p style="font-size: 12px; color: #718096;">' . __('If you were not expecting this invitation, please ignore this email.', 'mobooking') . '</p>';
+
+        $full_email_html = $this->get_styled_email_html($subject, get_bloginfo('name'), $body_content);
+
+        $headers = $this->get_email_headers();
+        return wp_mail($worker_email, $subject, $full_email_html, $headers);
+    }
 }


### PR DESCRIPTION
This commit fixes two critical errors in the invitation process:

1.  **JavaScript TypeError**: A `TypeError` in `dashboard-workers.js` that occurred during form validation has been resolved by adding a check to prevent calling `.trim()` on an undefined value.

2.  **AJAX 500 Error**: A fatal PHP error that caused a 500 Internal Server Error during the AJAX request to send an invitation has been fixed. The email sending logic has been moved to the `Notifications` class and is now called correctly from the `Auth` class, ensuring the autoloader can find all necessary classes.

These fixes ensure that the invitation form is now functional and that invitation emails are sent correctly using the standardized HTML template.