### PR TITLE
feat: Redesign Discounts page with ShadCN UI style and modal forms

### DIFF
--- a/assets/css/dashboard-discounts.css
+++ b/assets/css/dashboard-discounts.css
@@ -1,0 +1,140 @@
+/* ShadCN Inspired Styles for Discounts Page */
+.mobooking-discounts-page .button-primary {
+    background-color: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: var(--radius);
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.mobooking-discounts-page .button-primary:hover {
+    background-color: hsl(var(--primary) / 0.9);
+}
+
+.mobooking-discounts-page .wp-list-table {
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.mobooking-discounts-page .wp-list-table thead th {
+    background-color: hsl(var(--muted));
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.mobooking-discounts-page .wp-list-table tbody tr:not(.no-items) {
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.mobooking-discounts-page .wp-list-table tbody tr:last-child {
+    border-bottom: none;
+}
+
+.mobooking-discounts-page .wp-list-table .button {
+    background-color: hsl(var(--secondary));
+    color: hsl(var(--secondary-foreground));
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    padding: 0.25rem 0.5rem;
+}
+
+.mobooking-discounts-page .wp-list-table .button:hover {
+    background-color: hsl(var(--accent));
+}
+
+.mobooking-discounts-page .wp-list-table .button-link-delete {
+    color: hsl(var(--destructive));
+    border-color: transparent;
+    background: transparent;
+}
+
+.mobooking-discounts-page .wp-list-table .button-link-delete:hover {
+    color: hsl(var(--destructive-foreground));
+    background-color: hsl(var(--destructive));
+}
+
+.mobooking-discounts-page .status-active {
+    background-color: hsl(var(--accent));
+    color: hsl(var(--accent-foreground));
+    padding: 0.25rem 0.5rem;
+    border-radius: var(--radius);
+    font-weight: 500;
+}
+
+/* Modal Styles */
+.mobooking-modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1050;
+    width: 100vw;
+    height: 100vh;
+    background-color: hsla(var(--background), 0.8);
+    backdrop-filter: blur(4px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.mobooking-modal {
+    background-color: hsl(var(--card));
+    color: hsl(var(--card-foreground));
+    border-radius: var(--radius);
+    box-shadow: 0 10px 25px -5px rgba(0,0,0,0.1), 0 10px 10px -5px rgba(0,0,0,0.04);
+    border: 1px solid hsl(var(--border));
+    width: 100%;
+    max-width: 500px;
+}
+
+.mobooking-modal-content {
+    padding: 1.5rem;
+}
+
+.mobooking-modal-content h2 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-size: 1.25rem;
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+}
+
+.form-group label {
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+}
+
+.form-group input,
+.form-group select {
+    background-color: hsl(var(--background));
+    border: 1px solid hsl(var(--input));
+    border-radius: calc(var(--radius) - 2px);
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+}
+
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.mobooking-discounts-page .status-inactive {
+    background-color: hsl(var(--muted));
+    color: hsl(var(--muted-foreground));
+    padding: 0.25rem 0.5rem;
+    border-radius: var(--radius);
+    font-weight: 500;
+}

--- a/assets/js/dashboard-discounts.js
+++ b/assets/js/dashboard-discounts.js
@@ -3,11 +3,10 @@ jQuery(document).ready(function($) {
 
     const listContainer = $('#mobooking-discounts-list');
     const paginationContainer = $('#mobooking-discounts-pagination-container');
-    const formContainer = $('#mobooking-discount-form-container');
+    const modal = $('#mobooking-discount-modal');
     const form = $('#mobooking-discount-form');
     const formTitle = $('#mobooking-discount-form-title');
     const discountIdField = $('#mobooking-discount-id');
-    const feedbackDiv = $('#mobooking-discount-form-feedback');
     const itemTemplate = $('#mobooking-discount-item-template').html();
 
     let currentFilters = { paged: 1, limit: 20 }; // Basic pagination, filters can be added later
@@ -92,19 +91,19 @@ jQuery(document).ready(function($) {
         form[0].reset();
         discountIdField.val('');
         formTitle.text(mobooking_discounts_params.i18n.add_new_title || 'Add New Discount Code');
-        feedbackDiv.empty().removeClass('success error').hide();
-        formContainer.slideDown();
+        modal.fadeIn();
     });
 
     // Cancel Form
-    $('#mobooking-cancel-discount-form').on('click', function() {
-        formContainer.slideUp();
+    modal.on('click', '.mobooking-modal-close, .mobooking-modal-backdrop', function(e) {
+        if ($(e.target).is('.mobooking-modal-close') || $(e.target).is('.mobooking-modal-backdrop')) {
+            modal.fadeOut();
+        }
     });
 
     // Edit Discount
     listContainer.on('click', '.mobooking-edit-discount-btn', function() {
         const discountId = $(this).closest('tr').data('id');
-        feedbackDiv.empty().removeClass('success error').hide();
         form[0].reset(); // Clear form before populating
 
         $.ajax({
@@ -122,7 +121,7 @@ jQuery(document).ready(function($) {
                     $('#mobooking-discount-expiry').val(d.expiry_date || '');
                     $('#mobooking-discount-limit').val(d.usage_limit || '');
                     $('#mobooking-discount-status').val(d.status);
-                    formContainer.slideDown();
+                    modal.fadeIn();
                 } else {
                     alert(response.data.message || 'Error fetching details.');
                 }
@@ -153,7 +152,6 @@ jQuery(document).ready(function($) {
     // Form Submission (Add/Edit)
     form.on('submit', function(e) {
         e.preventDefault();
-        feedbackDiv.empty().removeClass('success error').hide();
         const submitButton = $('#mobooking-save-discount-btn');
         const originalButtonText = submitButton.text();
         submitButton.prop('disabled', true).text(mobooking_discounts_params.i18n.saving || 'Saving...');
@@ -173,7 +171,7 @@ jQuery(document).ready(function($) {
             success: function(response) {
                 if (response.success) {
                     window.showAlert(response.data.message, 'success');
-                    formContainer.slideUp();
+                    modal.fadeOut();
                     loadDiscounts(discountIdField.val() ? currentFilters.paged : 1); // Refresh current page on edit, or go to page 1 on add
                 } else {
                     window.showAlert(response.data.message || 'Error saving.', 'error');
@@ -184,7 +182,6 @@ jQuery(document).ready(function($) {
             },
             complete: function() {
                 submitButton.prop('disabled', false).text(originalButtonText);
-                 setTimeout(function() { feedbackDiv.fadeOut().empty(); }, 4000);
             }
         });
     });

--- a/dashboard/page-discounts.php
+++ b/dashboard/page-discounts.php
@@ -28,64 +28,13 @@ $total_pages = ceil($total_discounts / $per_page);
 wp_nonce_field('mobooking_dashboard_nonce', 'mobooking_dashboard_nonce_field');
 
 ?>
-<div style="display: flex; justify-content: space-between; align-items: center;">
-    <h1><?php esc_html_e('Manage Discount Codes', 'mobooking'); ?></h1>
-    <button id="mobooking-add-new-discount-btn" class="button button-primary"><?php esc_html_e('Add New Discount Code', 'mobooking'); ?></button>
-</div>
+<div class="mobooking-discounts-page">
+    <div class="page-header" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
+        <h1 class="text-2xl font-bold"><?php esc_html_e('Manage Discount Codes', 'mobooking'); ?></h1>
+        <button id="mobooking-add-new-discount-btn" class="button button-primary"><?php esc_html_e('Add New Discount Code', 'mobooking'); ?></button>
+    </div>
 
-<div id="mobooking-discount-form-container" style="display:none; margin-top:20px; padding:20px; background:#fff; border:1px solid #ccd0d4; max-width:600px; border-radius:4px;">
-    <h2 id="mobooking-discount-form-title" style="margin-top:0;"><?php esc_html_e('Add New Discount Code', 'mobooking'); ?></h2>
-    <form id="mobooking-discount-form">
-        <input type="hidden" id="mobooking-discount-id" name="discount_id" value="">
-        <table class="form-table">
-            <tr valign="top">
-                <th scope="row"><label for="mobooking-discount-code"><?php esc_html_e('Discount Code:', 'mobooking'); ?> <span class="required" style="color:red;">*</span></label></th>
-                <td><input type="text" id="mobooking-discount-code" name="code" class="regular-text" required>
-                    <p class="description"><?php esc_html_e('E.g., SUMMER20, SAVE10. Customers will use this code.', 'mobooking'); ?></p></td>
-            </tr>
-            <tr valign="top">
-                <th scope="row"><label for="mobooking-discount-type"><?php esc_html_e('Type:', 'mobooking'); ?> <span class="required" style="color:red;">*</span></label></th>
-                <td>
-                    <select id="mobooking-discount-type" name="type">
-                        <option value="percentage"><?php esc_html_e('Percentage', 'mobooking'); ?></option>
-                        <option value="fixed_amount"><?php esc_html_e('Fixed Amount', 'mobooking'); ?></option>
-                    </select>
-                </td>
-            </tr>
-            <tr valign="top">
-                <th scope="row"><label for="mobooking-discount-value"><?php esc_html_e('Value:', 'mobooking'); ?> <span class="required" style="color:red;">*</span></label></th>
-                <td><input type="number" id="mobooking-discount-value" name="value" step="0.01" min="0.01" class="small-text" required>
-                    <p class="description"><?php esc_html_e('E.g., 10 for 10% or 10 for $10.00 (or other currency).', 'mobooking'); ?></p></td>
-            </tr>
-            <tr valign="top">
-                <th scope="row"><label for="mobooking-discount-expiry"><?php esc_html_e('Expiry Date (optional):', 'mobooking'); ?></label></th>
-                <td><input type="text" id="mobooking-discount-expiry" name="expiry_date" class="mobooking-datepicker regular-text" placeholder="YYYY-MM-DD" autocomplete="off"></td>
-            </tr>
-            <tr valign="top">
-                <th scope="row"><label for="mobooking-discount-limit"><?php esc_html_e('Usage Limit (optional):', 'mobooking'); ?></label></th>
-                <td><input type="number" id="mobooking-discount-limit" name="usage_limit" step="1" min="0" class="small-text" placeholder="<?php esc_attr_e('e.g., 100', 'mobooking'); ?>">
-                    <p class="description"><?php esc_html_e('Max number of times this code can be used. Leave blank or 0 for unlimited.', 'mobooking'); ?></p></td>
-            </tr>
-            <tr valign="top">
-                <th scope="row"><label for="mobooking-discount-status"><?php esc_html_e('Status:', 'mobooking'); ?></label></th>
-                <td>
-                    <select id="mobooking-discount-status" name="status">
-                        <option value="active"><?php esc_html_e('Active', 'mobooking'); ?></option>
-                        <option value="inactive"><?php esc_html_e('Inactive', 'mobooking'); ?></option>
-                    </select>
-                </td>
-            </tr>
-        </table>
-        <p class="submit">
-            <button type="submit" id="mobooking-save-discount-btn" class="button button-primary"><?php esc_html_e('Save Discount Code', 'mobooking'); ?></button>
-            <button type="button" id="mobooking-cancel-discount-form" class="button" style="margin-left:10px;"><?php esc_html_e('Cancel', 'mobooking'); ?></button>
-        </p>
-        <div id="mobooking-discount-form-feedback" style="margin-top:10px; padding:8px; border-radius:3px;"></div>
-    </form>
-</div>
-
-<h2 style="margin-top:30px;"><?php esc_html_e('Your Discount Codes', 'mobooking'); ?></h2>
-<div id="mobooking-discounts-list-container">
+    <div id="mobooking-discounts-list-container">
     <table class="wp-list-table widefat striped fixed">
         <thead>
             <tr>
@@ -109,16 +58,16 @@ wp_nonce_field('mobooking_dashboard_nonce', 'mobooking_dashboard_nonce_field');
                     $usage_display = esc_html($discount['times_used']) . ' / ' . esc_html($usage_limit_display);
                     $status_display = $discount['status'] === 'active' ? __('Active', 'mobooking') : __('Inactive', 'mobooking');
                     ?>
-                    <tr class="mobooking-discount-item <?php echo $discount['status'] !== 'active' ? 'inactive-row' : ''; ?>" data-id="<?php echo esc_attr($discount['discount_id']); ?>">
+                    <tr class="mobooking-discount-item" data-id="<?php echo esc_attr($discount['discount_id']); ?>">
                         <td data-label="<?php esc_attr_e('Code', 'mobooking'); ?>"><strong><?php echo esc_html($discount['code']); ?></strong></td>
                         <td data-label="<?php esc_attr_e('Type', 'mobooking'); ?>"><?php echo esc_html($type_display); ?></td>
                         <td data-label="<?php esc_attr_e('Value', 'mobooking'); ?>"><?php echo wp_kses_post($value_display); // Currency might have HTML ?></td>
                         <td data-label="<?php esc_attr_e('Expiry', 'mobooking'); ?>"><?php echo esc_html($expiry_date_display); ?></td>
                         <td data-label="<?php esc_attr_e('Usage (Used/Limit)', 'mobooking'); ?>"><?php echo esc_html($usage_display); ?></td>
-                        <td data-label="<?php esc_attr_e('Status', 'mobooking'); ?>"><span class="status-<?php echo esc_attr($discount['status']); ?>" style="padding: 3px 6px; border-radius: 3px; background-color: #eee; font-weight:bold;"><?php echo esc_html($status_display); ?></span></td>
+                        <td data-label="<?php esc_attr_e('Status', 'mobooking'); ?>"><span class="status-<?php echo esc_attr($discount['status']); ?>"><?php echo esc_html($status_display); ?></span></td>
                         <td data-label="<?php esc_attr_e('Actions', 'mobooking'); ?>">
                             <button class="button button-small mobooking-edit-discount-btn" data-id="<?php echo esc_attr($discount['discount_id']); ?>"><?php esc_html_e('Edit', 'mobooking'); ?></button>
-                            <button class="button button-small button-link-delete mobooking-delete-discount-btn" data-id="<?php echo esc_attr($discount['discount_id']); ?>" style="margin-left:5px;"><?php esc_html_e('Delete', 'mobooking'); ?></button>
+                            <button class="button button-small button-link-delete mobooking-delete-discount-btn" data-id="<?php echo esc_attr($discount['discount_id']); ?>"><?php esc_html_e('Delete', 'mobooking'); ?></button>
                         </td>
                     </tr>
                 <?php endforeach; ?>
@@ -146,16 +95,64 @@ wp_nonce_field('mobooking_dashboard_nonce', 'mobooking_dashboard_nonce_field');
 </div>
 
 <script type="text/template" id="mobooking-discount-item-template">
-    <tr class="mobooking-discount-item <% if (status !== 'active') { %>inactive-row<% } %>" data-id="<%= discount_id %>">
+    <tr class="mobooking-discount-item" data-id="<%= discount_id %>">
         <td data-label="<?php esc_attr_e('Code', 'mobooking'); ?>"><strong><%= code %></strong></td>
         <td data-label="<?php esc_attr_e('Type', 'mobooking'); ?>"><%= type_display %></td>
         <td data-label="<?php esc_attr_e('Value', 'mobooking'); ?>"><%= value_display %></td>
         <td data-label="<?php esc_attr_e('Expiry', 'mobooking'); ?>"><%= expiry_date_display %></td>
         <td data-label="<?php esc_attr_e('Usage (Used/Limit)', 'mobooking'); ?>"><%= usage_display %></td>
-        <td data-label="<?php esc_attr_e('Status', 'mobooking'); ?>"><span class="status-<%= status %>" style="padding: 3px 6px; border-radius: 3px; background-color: #eee; font-weight:bold;"><%= status_display %></span></td>
+        <td data-label="<?php esc_attr_e('Status', 'mobooking'); ?>"><span class="status-<%= status %>"><%= status_display %></span></td>
         <td data-label="<?php esc_attr_e('Actions', 'mobooking'); ?>">
             <button class="button button-small mobooking-edit-discount-btn" data-id="<%= discount_id %>"><?php esc_html_e('Edit', 'mobooking'); ?></button>
-            <button class="button button-small button-link-delete mobooking-delete-discount-btn" data-id="<%= discount_id %>" style="margin-left:5px;"><?php esc_html_e('Delete', 'mobooking'); ?></button>
+            <button class="button button-small button-link-delete mobooking-delete-discount-btn" data-id="<%= discount_id %>"><?php esc_html_e('Delete', 'mobooking'); ?></button>
         </td>
     </tr>
 </script>
+
+<div id="mobooking-discount-modal" class="mobooking-modal-backdrop" style="display: none;">
+    <div class="mobooking-modal">
+        <div class="mobooking-modal-content">
+            <h2 id="mobooking-discount-form-title" class="text-lg font-semibold"></h2>
+            <form id="mobooking-discount-form">
+                <input type="hidden" id="mobooking-discount-id" name="discount_id" value="">
+                <div class="form-grid">
+                    <div class="form-group">
+                        <label for="mobooking-discount-code"><?php esc_html_e('Discount Code', 'mobooking'); ?></label>
+                        <input type="text" id="mobooking-discount-code" name="code" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="mobooking-discount-type"><?php esc_html_e('Type', 'mobooking'); ?></label>
+                        <select id="mobooking-discount-type" name="type">
+                            <option value="percentage"><?php esc_html_e('Percentage', 'mobooking'); ?></option>
+                            <option value="fixed_amount"><?php esc_html_e('Fixed Amount', 'mobooking'); ?></option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="mobooking-discount-value"><?php esc_html_e('Value', 'mobooking'); ?></label>
+                        <input type="number" id="mobooking-discount-value" name="value" step="0.01" min="0.01" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="mobooking-discount-expiry"><?php esc_html_e('Expiry Date', 'mobooking'); ?></label>
+                        <input type="text" id="mobooking-discount-expiry" name="expiry_date" class="mobooking-datepicker" placeholder="YYYY-MM-DD" autocomplete="off">
+                    </div>
+                    <div class="form-group">
+                        <label for="mobooking-discount-limit"><?php esc_html_e('Usage Limit', 'mobooking'); ?></label>
+                        <input type="number" id="mobooking-discount-limit" name="usage_limit" step="1" min="0" placeholder="<?php esc_attr_e('e.g., 100', 'mobooking'); ?>">
+                    </div>
+                    <div class="form-group">
+                        <label for="mobooking-discount-status"><?php esc_html_e('Status', 'mobooking'); ?></label>
+                        <select id="mobooking-discount-status" name="status">
+                            <option value="active"><?php esc_html_e('Active', 'mobooking'); ?></option>
+                            <option value="inactive"><?php esc_html_e('Inactive', 'mobooking'); ?></option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="button mobooking-modal-close"><?php esc_html_e('Cancel', 'mobooking'); ?></button>
+                    <button type="submit" id="mobooking-save-discount-btn" class="button button-primary"><?php esc_html_e('Save Discount', 'mobooking'); ?></button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+</div>

--- a/functions/routing.php
+++ b/functions/routing.php
@@ -144,6 +144,7 @@ function mobooking_enqueue_dashboard_scripts($current_page_slug = '') {
 
     // Specific to Discounts page
     if ($current_page_slug === 'discounts') {
+        wp_enqueue_style('mobooking-dashboard-discounts', MOBOOKING_THEME_URI . 'assets/css/dashboard-discounts.css', array(), MOBOOKING_VERSION);
         wp_enqueue_script('mobooking-dashboard-discounts', MOBOOKING_THEME_URI . 'assets/js/dashboard-discounts.js', array('jquery'), MOBOOKING_VERSION, true);
         $discounts_params = array_merge($dashboard_params, [
             'i18n' => [


### PR DESCRIPTION
- I redesigned the Discounts page to match the ShadCN UI style.
- I created a new CSS file `dashboard-discounts.css` for the new styles.
- I implemented a popup modal for the "Add New" and "Edit" actions.
- I updated the JavaScript to handle the modal and form submissions.