### PR TITLE
fix: Fix Discounts page JS error and duplicate CSS

### DIFF
--- a/assets/css/dashboard-discounts.css
+++ b/assets/css/dashboard-discounts.css
@@ -134,11 +134,3 @@
 .hidden {
     display: none;
 }
-
-.mobooking-discounts-page .status-inactive {
-    background-color: hsl(var(--muted));
-    color: hsl(var(--muted-foreground));
-    padding: 0.25rem 0.5rem;
-    border-radius: var(--radius);
-    font-weight: 500;
-}

--- a/functions/routing.php
+++ b/functions/routing.php
@@ -158,7 +158,15 @@ function mobooking_enqueue_dashboard_scripts($current_page_slug = '') {
                 'discount_saved' => __('Discount saved.', 'mobooking'),
                 'error_saving_discount' => __('Error saving discount.', 'mobooking'),
                 'saving' => __('Saving...', 'mobooking'),
-            ]
+            ],
+            'types' => [
+                'percentage' => __('Percentage', 'mobooking'),
+                'fixed_amount' => __('Fixed Amount', 'mobooking'),
+            ],
+            'statuses' => [
+                'active' => __('Active', 'mobooking'),
+                'inactive' => __('Inactive', 'mobooking'),
+            ],
         ]);
         wp_localize_script('mobooking-dashboard-discounts', 'mobooking_discounts_params', $discounts_params);
     }


### PR DESCRIPTION
- Fixed a JavaScript error on the Discounts page by passing the discount types and statuses to the `mobooking_discounts_params` object.
- Removed duplicate CSS from `assets/css/dashboard-discounts.css`.