### PR TITLE
fix: Make Discounts page table responsive

### DIFF
--- a/assets/css/dashboard-discounts.css
+++ b/assets/css/dashboard-discounts.css
@@ -183,3 +183,43 @@
 .form-group.full-width {
     grid-column: span 2;
 }
+
+@media screen and (max-width: 768px) {
+    .mobooking-table-container {
+        overflow-x: auto;
+    }
+
+    .wp-list-table thead,
+    .wp-list-table tfoot {
+        display: none;
+    }
+
+    .wp-list-table tbody tr {
+        display: block;
+        margin-bottom: 1rem;
+        border: 1px solid hsl(var(--border));
+        border-radius: var(--radius);
+    }
+
+    .wp-list-table tbody td {
+        display: block;
+        text-align: right;
+        border-bottom: 1px solid hsl(var(--border));
+        position: relative;
+        padding-left: 50%;
+    }
+
+    .wp-list-table tbody td:before {
+        content: attr(data-label);
+        position: absolute;
+        left: 0;
+        width: 45%;
+        padding-left: 1rem;
+        font-weight: 600;
+        text-align: left;
+    }
+
+    .wp-list-table tbody td:last-child {
+        border-bottom: none;
+    }
+}

--- a/dashboard/page-discounts.php
+++ b/dashboard/page-discounts.php
@@ -34,8 +34,8 @@ wp_nonce_field('mobooking_dashboard_nonce', 'mobooking_dashboard_nonce_field');
         <button id="mobooking-add-new-discount-btn" class="button button-primary"><?php esc_html_e('Add New Discount Code', 'mobooking'); ?></button>
     </div>
 
-    <div id="mobooking-discounts-list-container">
-    <table class="wp-list-table widefat striped fixed">
+    <div id="mobooking-discounts-list-container" class="mobooking-table-container">
+    <table class="wp-list-table widefat striped">
         <thead>
             <tr>
                 <th scope="col"><?php esc_html_e('Code', 'mobooking'); ?></th>


### PR DESCRIPTION
- Removed the `fixed` class from the table to allow for more flexibility.
- Added responsive styles to the table to ensure it displays correctly on smaller screens.