### PR TITLE
fix: Fix 400 error on Areas page

### DIFF
--- a/assets/js/enhanced-areas.js
+++ b/assets/js/enhanced-areas.js
@@ -85,6 +85,7 @@
     function loadCities() {
         $citiesGridContainer.html(`<div class="mobooking-loading-state"><div class="mobooking-spinner"></div><p>${i18n.loading_cities}</p></div>`);
 
+        console.log("Loading service coverage with filters:", filters);
         $.ajax({
             url: mobooking_areas_params.ajax_url,
             type: "POST",
@@ -193,6 +194,7 @@
      * Get already saved/enabled areas for a city
      */
     function getSavedAreasForCity(cityCode) {
+        console.log("Getting saved areas for city:", cityCode);
         return $.ajax({
             url: mobooking_areas_params.ajax_url,
             type: "POST",
@@ -202,6 +204,12 @@
                 city: cityCode,
                 limit: -1, // Get all
             },
+            success: function(response) {
+                console.log("Saved areas response:", response);
+            },
+            error: function(xhr) {
+                console.error("Error getting saved areas:", xhr.responseText);
+            }
         });
     }
 
@@ -316,13 +324,15 @@
                 filters: filters,
             },
             success: function (response) {
+                console.log("Service coverage response:", response);
                 if (response.success && response.data?.cities) {
                     renderCoverage(response.data.cities);
                 } else {
                     $coverageList.html(`<div class="mobooking-empty-state"><p>${i18n.no_coverage || 'No service coverage found.'}</p></div>`);
                 }
             },
-            error: function () {
+            error: function (xhr) {
+                console.error("Error loading service coverage:", xhr.responseText);
                 $coverageList.html(`<div class="mobooking-error-state"><p>${i18n.error}</p></div>`);
             },
         });

--- a/classes/Areas.php
+++ b/classes/Areas.php
@@ -536,6 +536,61 @@ public function get_areas_for_city($country_code, $city_code) {
         wp_send_json_success(['areas' => $areas]);
     }
 
+    public function get_service_coverage_grouped($filters = []) {
+        $user_id = get_current_user_id();
+        if (empty($user_id)) {
+            return new \WP_Error('invalid_user', __('Invalid user.', 'mobooking'));
+        }
+
+        $table_name = Database::get_table_name('service_areas');
+        $where_conditions = ['user_id = %d'];
+        $where_values = [$user_id];
+
+        if (!empty($filters['city'])) {
+            $where_conditions[] = 'area_name = %s';
+            $where_values[] = sanitize_text_field($filters['city']);
+        }
+
+        if (!empty($filters['status'])) {
+            $where_conditions[] = 'status = %s';
+            $where_values[] = sanitize_text_field($filters['status']);
+        }
+
+        $where_clause = 'WHERE ' . implode(' AND ', $where_conditions);
+        $sql = "SELECT area_name as city_name, COUNT(area_id) as area_count, status, country_code as city_code FROM $table_name $where_clause GROUP BY area_name, status, country_code ORDER BY area_name ASC";
+        $results = $this->wpdb->get_results($this->wpdb->prepare($sql, $where_values), ARRAY_A);
+
+        return ['cities' => $results];
+    }
+
+    public function get_service_coverage($city, $limit) {
+        $user_id = get_current_user_id();
+        if (empty($user_id)) {
+            return new \WP_Error('invalid_user', __('Invalid user.', 'mobooking'));
+        }
+
+        $table_name = Database::get_table_name('service_areas');
+        $where_conditions = ['user_id = %d'];
+        $where_values = [$user_id];
+
+        if (!empty($city)) {
+            $where_conditions[] = 'area_name = %s';
+            $where_values[] = sanitize_text_field($city);
+        }
+
+        $where_clause = 'WHERE ' . implode(' AND ', $where_conditions);
+
+        $limit_clause = '';
+        if ($limit > 0) {
+            $limit_clause = $this->wpdb->prepare('LIMIT %d', $limit);
+        }
+
+        $sql = "SELECT * FROM $table_name $where_clause ORDER BY area_value ASC $limit_clause";
+        $results = $this->wpdb->get_results($this->wpdb->prepare($sql, $where_values), ARRAY_A);
+
+        return ['areas' => $results];
+    }
+
     /**
      * Handle public ZIP code availability check
      */

--- a/functions/ajax.php
+++ b/functions/ajax.php
@@ -719,4 +719,43 @@ function mobooking_ajax_get_public_services() {
 
     wp_send_json_success($services);
 }
+
+add_action('wp_ajax_mobooking_get_service_coverage_grouped', 'mobooking_ajax_get_service_coverage_grouped');
+function mobooking_ajax_get_service_coverage_grouped() {
+    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'mobooking_areas_nonce')) {
+        wp_send_json_error(array('message' => 'Security check failed: Invalid nonce.'), 403);
+        return;
+    }
+
+    $areas_manager = new \MoBooking\Classes\Areas();
+    $filters = isset($_POST['filters']) ? $_POST['filters'] : [];
+    $result = $areas_manager->get_service_coverage_grouped($filters);
+
+    if (is_wp_error($result)) {
+        wp_send_json_error(array('message' => $result->get_error_message()), 500);
+        return;
+    }
+
+    wp_send_json_success($result);
+}
+
+add_action('wp_ajax_mobooking_get_service_coverage', 'mobooking_ajax_get_service_coverage');
+function mobooking_ajax_get_service_coverage() {
+    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'mobooking_areas_nonce')) {
+        wp_send_json_error(array('message' => 'Security check failed: Invalid nonce.'), 403);
+        return;
+    }
+
+    $areas_manager = new \MoBooking\Classes\Areas();
+    $city = isset($_POST['city']) ? sanitize_text_field($_POST['city']) : '';
+    $limit = isset($_POST['limit']) ? intval($_POST['limit']) : -1;
+    $result = $areas_manager->get_service_coverage($city, $limit);
+
+    if (is_wp_error($result)) {
+        wp_send_json_error(array('message' => $result->get_error_message()), 500);
+        return;
+    }
+
+    wp_send_json_success($result);
+}
 ?>

--- a/functions/routing.php
+++ b/functions/routing.php
@@ -189,6 +189,7 @@ function mobooking_enqueue_dashboard_scripts($current_page_slug = '') {
                 'saving' => __('Saving...', 'mobooking'),
             ]
         ]);
+        $areas_params['nonce'] = wp_create_nonce('mobooking_areas_nonce');
         wp_localize_script('mobooking-dashboard-areas', 'mobooking_areas_params', $areas_params);
     }
 


### PR DESCRIPTION
- Added missing AJAX action handlers for `mobooking_get_service_coverage_grouped` and `mobooking_get_service_coverage`.
- Added the corresponding methods to the `Areas` class.
- Added a nonce to the `wp_localize_script` call for the areas page.
- Added debug logging to the JavaScript to help diagnose future issues.