### PR TITLE
I've fixed the JavaScript error on the Areas page. The issue was an i…

### DIFF
--- a/assets/js/enhanced-areas.js
+++ b/assets/js/enhanced-areas.js
@@ -85,7 +85,6 @@
     function loadCities() {
         $citiesGridContainer.html(`<div class="mobooking-loading-state"><div class="mobooking-spinner"></div><p>${i18n.loading_cities}</p></div>`);
 
-        console.log("Loading service coverage with filters:", filters);
         $.ajax({
             url: mobooking_areas_params.ajax_url,
             type: "POST",


### PR DESCRIPTION
…ncorrect `console.log` statement that was causing a "filters is not defined" error, which I have now removed.