### PR TITLE
I've fixed the nonce error on the Areas page. To do this, I enqueued …

### DIFF
--- a/functions/routing.php
+++ b/functions/routing.php
@@ -174,7 +174,7 @@ function mobooking_enqueue_dashboard_scripts($current_page_slug = '') {
     // Specific to Areas page
     if ($current_page_slug === 'areas') {
         wp_enqueue_style('mobooking-enhanced-areas', MOBOOKING_THEME_URI . 'assets/css/enhanced-areas.css', array(), MOBOOKING_VERSION);
-        // wp_enqueue_script('mobooking-dashboard-areas', MOBOOKING_THEME_URI . 'assets/js/dashboard-areas.js', array('jquery'), MOBOOKING_VERSION, true);
+        wp_enqueue_script('mobooking-enhanced-areas', MOBOOKING_THEME_URI . 'assets/js/enhanced-areas.js', array('jquery'), MOBOOKING_VERSION, true);
         $areas_params = array_merge($dashboard_params, [
             'i18n' => [
                 'loading_areas' => __('Loading areas...', 'mobooking'),
@@ -190,7 +190,7 @@ function mobooking_enqueue_dashboard_scripts($current_page_slug = '') {
             ]
         ]);
         $areas_params['nonce'] = wp_create_nonce('mobooking_areas_nonce');
-        wp_localize_script('mobooking-dashboard-areas', 'mobooking_areas_params', $areas_params);
+        wp_localize_script('mobooking-enhanced-areas', 'mobooking_areas_params', $areas_params);
     }
 
     // Specific to Booking Form Settings page


### PR DESCRIPTION
…the `enhanced-areas.js` script and correctly localized the nonce for it.