### PR TITLE
Fix: Fix JavaScript and nonce errors on Areas page

### DIFF
--- a/functions/ajax.php
+++ b/functions/ajax.php
@@ -722,7 +722,7 @@ function mobooking_ajax_get_public_services() {
 
 add_action('wp_ajax_mobooking_get_service_coverage_grouped', 'mobooking_ajax_get_service_coverage_grouped');
 function mobooking_ajax_get_service_coverage_grouped() {
-    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'mobooking_areas_nonce')) {
+    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'mobooking_dashboard_nonce')) {
         wp_send_json_error(array('message' => 'Security check failed: Invalid nonce.'), 403);
         return;
     }
@@ -741,7 +741,7 @@ function mobooking_ajax_get_service_coverage_grouped() {
 
 add_action('wp_ajax_mobooking_get_service_coverage', 'mobooking_ajax_get_service_coverage');
 function mobooking_ajax_get_service_coverage() {
-    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'mobooking_areas_nonce')) {
+    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'mobooking_dashboard_nonce')) {
         wp_send_json_error(array('message' => 'Security check failed: Invalid nonce.'), 403);
         return;
     }

--- a/functions/routing.php
+++ b/functions/routing.php
@@ -174,7 +174,7 @@ function mobooking_enqueue_dashboard_scripts($current_page_slug = '') {
     // Specific to Areas page
     if ($current_page_slug === 'areas') {
         wp_enqueue_style('mobooking-enhanced-areas', MOBOOKING_THEME_URI . 'assets/css/enhanced-areas.css', array(), MOBOOKING_VERSION);
-        wp_enqueue_script('mobooking-enhanced-areas', MOBOOKING_THEME_URI . 'assets/js/enhanced-areas.js', array('jquery'), MOBOOKING_VERSION, true);
+        wp_enqueue_script('mobooking-enhanced-areas', MOBOOKING_THEME_URI . 'assets/js/enhanced-areas.js', array('jquery', 'wp-i18n'), MOBOOKING_VERSION, true);
         $areas_params = array_merge($dashboard_params, [
             'i18n' => [
                 'loading_areas' => __('Loading areas...', 'mobooking'),


### PR DESCRIPTION
- Added `wp-i18n` as a dependency for the `mobooking-enhanced-areas` script to fix the "wp.i18n is not defined" error.
- Changed the nonce being checked in `functions/ajax.php` to `mobooking_dashboard_nonce` to fix the "Security check failed: Invalid nonce." error.