### PR TITLE
Fix: Ensure booking form automatically advances to the next step

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -487,6 +487,7 @@ jQuery(document).ready(function ($) {
     $('[data-step-next="3"]').prop("disabled", false);
     showFeedback($("#mobooking-services-feedback"), "", "", true);
     updateLiveSummary();
+    handleNextStep();
   }
 
   // --- STEP 3: SERVICE OPTIONS ---
@@ -510,6 +511,7 @@ jQuery(document).ready(function ($) {
           I18N.no_options || "No additional options available."
         }</p></div>`
       );
+      handleNextStep();
       return;
     }
 


### PR DESCRIPTION
This commit fixes an issue where the booking form would not automatically advance to the next step after a service was selected. The `handleServiceSelect` and `displayServiceOptions` functions have been modified to call `handleNextStep()` to ensure a smooth user experience.