### PR TITLE
I've added server-side logging for nonce verification. This should he…

### DIFF
--- a/classes/BookingFormAjax.php
+++ b/classes/BookingFormAjax.php
@@ -197,8 +197,12 @@ class BookingFormAjax {
      * Get service options for selected services
      */
     public function handle_get_service_options() {
-        if (!check_ajax_referer('mobooking_booking_form_nonce', 'nonce', false)) {
-            wp_send_json_error(['message' => __('Security check failed.', 'mobooking')], 403);
+        error_log('[MoBooking AJAX Debug] Received POST for get_service_options: ' . print_r($_POST, true));
+        $nonce_verified = check_ajax_referer('mobooking_booking_form_nonce', 'nonce', false);
+        error_log('[MoBooking AJAX Debug] Nonce verification result: ' . ($nonce_verified ? 'SUCCESS' : 'FAILURE'));
+
+        if (!$nonce_verified) {
+            wp_send_json_error(['message' => 'Error: Nonce verification failed.'], 403);
             return;
         }
 


### PR DESCRIPTION
…lp me debug a persistent nonce verification failure. I'll be logging the received POST data and the result of the `check_ajax_referer` function to the server's error log. This is a temporary debugging step to diagnose the issue.