### PR TITLE
Fix service option rendering in booking form

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -616,9 +616,27 @@
           option.required ? "required" : ""
         }>`;
         if (option.option_values) {
-          option.option_values.forEach(function (value) {
-            html += `<option value="${value}">${value}</option>`;
-          });
+          let values = option.option_values;
+          // Robustness: check if it's a string and try to parse it.
+          if (typeof values === 'string') {
+            try {
+              values = JSON.parse(values);
+            } catch (e) {
+              DebugTree.error('Failed to parse option_values for select', { optionId: option.id, values: option.option_values });
+              values = [];
+            }
+          }
+
+          if (Array.isArray(values)) {
+            values.forEach(function (item) {
+              // Handle both object {label, value} and simple string values
+              if (typeof item === 'object' && item !== null && item.hasOwnProperty('label') && item.hasOwnProperty('value')) {
+                html += `<option value="${item.value}">${item.label}</option>`;
+              } else {
+                html += `<option value="${item}">${item}</option>`;
+              }
+            });
+          }
         }
         html += "</select>";
       } else if (option.type === "checkbox") {

--- a/classes/ServiceOptions.php
+++ b/classes/ServiceOptions.php
@@ -198,8 +198,20 @@ class ServiceOptions {
         $table_name = Database::get_table_name('service_options');
         $options = $this->wpdb->get_results( $this->wpdb->prepare( "SELECT * FROM $table_name WHERE service_id = %d AND user_id = %d ORDER BY sort_order ASC", $service_id, $user_id ), ARRAY_A );
 
-        // As with get_service_option, no automatic decoding of option_values.
-        return $options; // Returns array of arrays, option_values is JSON string.
+        // Decode option_values from JSON string to array
+        foreach ($options as $key => $option) {
+            if (!empty($option['option_values']) && is_string($option['option_values'])) {
+                $decoded_values = json_decode($option['option_values'], true);
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $options[$key]['option_values'] = $decoded_values;
+                } else {
+                    // Handle broken JSON, maybe default to empty array
+                    $options[$key]['option_values'] = [];
+                }
+            }
+        }
+
+        return $options;
     }
 
     public function update_service_option(int $option_id, int $user_id, array $data) {


### PR DESCRIPTION
This commit addresses a TypeError crash in the public booking form that occurred when rendering service options of the 'select' type.

The root cause was a backend and frontend mismatch. The AJAX handler in `classes/Services.php` was fetching service options from `classes/ServiceOptions.php`, which returned the `option_values` field as an unprocessed JSON string from the database. The frontend JavaScript expected this to be an array and crashed when calling `.forEach` on the string.

The fix is two-fold:
1.  **Backend:** The `get_service_options` method in `classes/ServiceOptions.php` has been updated to correctly `json_decode` the `option_values` string into a PHP array before returning it. This ensures the data sent to the client is in the correct format.
2.  **Frontend:** The `renderServiceOptions` function in `assets/js/booking-form-public.js` has been made more robust. It now correctly iterates over the array of option objects, using the `label` and `value` properties to build the dropdown. This prevents the UI from displaying `[object Object]` and handles the data as intended.