### PR TITLE
Feat: Modernize service option inputs

### DIFF
--- a/assets/css/booking-form-modern.css
+++ b/assets/css/booking-form-modern.css
@@ -1809,6 +1809,42 @@ body.mobooking-form-active {
    margin-right: 0.5rem;
 }
 
+/* Modern Radio Button Cards */
+.mobooking-bf__radio-card {
+    display: block;
+    border: 1px solid var(--mobk-color-border);
+    border-radius: var(--mobk-border-radius);
+    padding: 1rem;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    position: relative;
+}
+
+.mobooking-bf__radio-card:hover {
+    border-color: var(--mobk-color-primary);
+    box-shadow: 0 0 0 1px var(--mobk-color-primary);
+}
+
+.mobooking-bf__radio-card-input {
+    display: none; /* Equivalent to 'hidden' and 'peer' */
+}
+
+.mobooking-bf__radio-card-input:checked + .mobooking-bf__radio-card-content {
+    border-color: var(--mobk-color-primary);
+    box-shadow: 0 0 0 2px var(--mobk-color-ring);
+    border-radius: var(--mobk-border-radius);
+}
+
+.mobooking-bf__radio-card-title {
+    font-weight: 600;
+    color: var(--mobk-color-card-foreground);
+}
+
+.mobooking-bf__radio-card-subtitle {
+    font-size: 0.875rem;
+    color: var(--mobk-color-muted-foreground);
+}
+
 /* Print Styles for Confirmation */
 @media print {
    .mobooking-success-actions {


### PR DESCRIPTION
This commit introduces a significant UI upgrade for several service option input types in the public booking form, based on your designs.

The `renderServiceOptions` function in `assets/js/booking-form-public.js` has been updated to generate new HTML structures for the following types:

- **Number/Quantity:** Replaced the standard number input with a modern version that includes `+` and `-` buttons for easier value manipulation.
- **Radio:** Replaced standard radio buttons with a card-based design. Each option is a clickable card with a title and description. The corresponding CSS has been added to `assets/css/booking-form-modern.css` to support this new design.
- **SQM:** Implemented a composite control that includes both a range slider and a number input, which are synchronized via `oninput` event handlers.
- **Select:** Replaced the native `<select>` element with a custom, `div`-based dropdown. This required adding new global JavaScript functions (`toggleDropdown`, `selectDropdownOption`) and an event listener to manage the dropdown's state and user interactions.

These changes significantly improve the user experience of the booking form by providing more modern, interactive, and user-friendly input controls.