### PR TITLE
Fix: Correct tenant_id submission

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -1107,7 +1107,6 @@
 
     // Construct the data structure expected by the backend
     const bookingPayload = {
-      tenant_id: CONFIG.tenant_id,
       customer: {
         ...formData.customer,
         date: formData.datetime.date,
@@ -1130,6 +1129,7 @@
     const ajaxData = {
       action: 'mobooking_create_booking',
       nonce: CONFIG.nonce,
+      tenant_id: CONFIG.tenant_id, // Send tenant_id at the top level
       booking_data: JSON.stringify(bookingPayload)
     };
 


### PR DESCRIPTION
This commit fixes an issue where the booking form was not saving to the database due to an 'Invalid tenant information' error.

The `submitBooking` function in `assets/js/booking-form-public.js` has been updated to send the `tenant_id` as a top-level parameter in the AJAX request, rather than inside the `booking_data` JSON string. This matches the backend's expectations and resolves the validation error.