### PR TITLE
fix: Correct staff assignment validation logic

### DIFF
--- a/classes/Bookings.php
+++ b/classes/Bookings.php
@@ -1518,7 +1518,8 @@ foreach ($calculated_service_items as $service_item) {
             $booking_owner_id = $this->get_booking_owner_id($booking_id);
             if ($booking_owner_id) {
                 $staff_owner_id = Auth::get_business_owner_id_for_worker($staff_id);
-                if ($booking_owner_id !== $staff_owner_id) {
+                if ((int)$booking_owner_id !== (int)$staff_owner_id) {
+                    error_log("MoBooking - Staff assignment failed: Booking owner ID ({$booking_owner_id}) does not match staff owner ID ({$staff_owner_id}).");
                     wp_send_json_error(['message' => __('Staff member does not belong to this business.', 'mobooking')], 403);
                     return;
                 }


### PR DESCRIPTION
- Fixed a bug where assigning a staff member to a booking would fail with a 'Staff member does not belong to this business' error.
- The issue was caused by a strict type comparison (!==) between the booking owner ID (integer) and the staff owner ID (string from user meta).
- The fix ensures both IDs are cast to integers before comparison, resolving the type mismatch and allowing valid staff assignments.