### PR TITLE
fix: Resolve fatal error on My Assigned Bookings page

### DIFF
--- a/dashboard/page-my-assigned-bookings.php
+++ b/dashboard/page-my-assigned-bookings.php
@@ -42,7 +42,7 @@ if ( !class_exists('MoBooking\Classes\Bookings') || !class_exists('MoBooking\Cla
 // This part will be fleshed out once we know how $bookings_manager is typically made available in dashboard pages.
 // For the purpose of this step, we will focus on the structure and the query modification.
 
-$currency_symbol = \MoBooking\Classes\Utils::get_currency_symbol(); // Or get specific to business owner
+$currency_symbol = '$'; // Default currency symbol
 if (isset($GLOBALS['mobooking_settings_manager'])) {
     $currency_code_setting = $GLOBALS['mobooking_settings_manager']->get_setting($business_owner_id, 'biz_currency_code', 'USD');
     $currency_symbol = \MoBooking\Classes\Utils::get_currency_symbol($currency_code_setting);


### PR DESCRIPTION
- I fixed a fatal error caused by calling `get_currency_symbol` with no arguments.
- I replaced the erroneous function call with a default value for the currency symbol.
- The subsequent code correctly fetches the currency symbol from settings, so the page will now load correctly for you.