### PR TITLE
fix: Correct dashboard header functionality and consolidate CSS

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -973,7 +973,7 @@ table.mobooking-table {
     transition: transform 0.2s ease;
 }
 
-.user-menu.open .chevron-down {
+.user-menu.active .chevron-down {
     transform: rotate(180deg);
 }
 
@@ -996,7 +996,7 @@ table.mobooking-table {
     pointer-events: none;
 }
 
-.user-menu.open .user-dropdown-menu {
+.user-menu.active .user-dropdown-menu {
     opacity: 1;
     transform: translateY(0);
     pointer-events: auto;

--- a/assets/js/dashboard-header.js
+++ b/assets/js/dashboard-header.js
@@ -8,12 +8,12 @@ jQuery(document).ready(function($) {
 
     userMenuToggle.on('click', function(e) {
         e.stopPropagation();
-        userMenu.toggleClass('open');
+        userMenu.toggleClass('active');
     });
 
     $(document).on('click', function(e) {
-        if (userMenu.hasClass('open') && !$(e.target).closest('.user-menu').length) {
-            userMenu.removeClass('open');
+        if (userMenu.hasClass('active') && !$(e.target).closest('.user-menu').length) {
+            userMenu.removeClass('active');
         }
     });
 
@@ -47,7 +47,7 @@ jQuery(document).ready(function($) {
             searchResultsList.html('<p>Searching...</p>');
 
             $.ajax({
-                url: ajaxurl, // WordPress AJAX URL
+                url: mobooking_dashboard_params.ajax_url,
                 type: 'POST',
                 data: {
                     action: 'mobooking_dashboard_live_search',


### PR DESCRIPTION
This commit fixes several issues related to the new dashboard header and completes the consolidation of all dashboard-related CSS into a single file.

Key changes:
- Fixed a JavaScript error where `ajaxurl` was not defined by using the localized `ajax_url` parameter from `mobooking_dashboard_params`.
- Corrected the user menu toggle functionality by changing the toggled class from `open` to `active` and updating the CSS to match.
- Appended the content of `assets/css/dashboard-cards.css` and `assets/css/dashboard-header.css` to `assets/css/dashboard.css`.
- Deleted the now-redundant `assets/css/dashboard-cards.css` and `assets/css/dashboard-header.css` files.
- Updated `functions/theme-setup.php` to remove the `wp_enqueue_style` calls for the deleted files, ensuring only `dashboard.css` is loaded for all dashboard styles.