### PR TITLE
fix: Correct services page loading and add sidebar CSS import

### DIFF
--- a/assets/css/dashboard-main.css
+++ b/assets/css/dashboard-main.css
@@ -6,3 +6,4 @@
 @import url("toast.css");
 @import url("toggle-switch.css");
 @import url("dashboard-workers-enhanced.css");
+@import url("mobooking-dashboard-sidebar-enhanced.css");

--- a/functions/theme-setup.php
+++ b/functions/theme-setup.php
@@ -336,6 +336,19 @@ if ( is_page_template('templates/booking-form-public.php') || $page_type_for_scr
             'nonce' => wp_create_nonce('mobooking_dashboard_nonce')
         ]);
 
+        if ( $current_page_slug === 'services' ) {
+            wp_enqueue_script('mobooking-services-js', MOBOOKING_THEME_URI . 'assets/js/dashboard-services.js', array('jquery'), MOBOOKING_VERSION, true);
+            wp_localize_script('mobooking-services-js', 'mobooking_services_params', [
+                'ajax_url' => admin_url('admin-ajax.php'),
+                'nonce' => wp_create_nonce('mobooking_services_nonce'),
+                'i18n' => [
+                    'loading_services' => __('Loading...', 'mobooking'),
+                    'no_services_found' => __('No services found.', 'mobooking'),
+                    'confirm_delete_service' => __('Are you sure you want to delete this service?', 'mobooking'),
+                ],
+            ]);
+        }
+
         if ( $current_page_slug === 'workers' ) {
             wp_enqueue_script( 'mobooking-dashboard-workers', MOBOOKING_THEME_URI . 'assets/js/dashboard-workers.js', array( 'jquery', 'mobooking-dialog' ), MOBOOKING_VERSION, true );
             wp_localize_script( 'mobooking-dashboard-workers', 'mobooking_workers_params', array(


### PR DESCRIPTION
This commit fixes a bug that prevented services from being displayed on the services page and adds a missing CSS import for the dashboard sidebar.

Key changes:
- Added a `wp_localize_script` call in `functions/theme-setup.php` to provide the necessary nonce and other parameters to the `dashboard-services.js` script. This resolves the issue where services were not being loaded via AJAX.
- Added an `@import` rule for `mobooking-dashboard-sidebar-enhanced.css` to the main `dashboard-main.css` file to ensure the sidebar is styled correctly.