### PR TITLE
Final Fixes for Services Page

### DIFF
--- a/assets/js/dashboard-services.js
+++ b/assets/js/dashboard-services.js
@@ -63,9 +63,6 @@
       $(document).on("click", ".service-delete-btn", (e) =>
         this.handleDeleteService(e)
       );
-      $(document).on("click", ".service-duplicate-btn", (e) =>
-        this.handleDuplicateService(e)
-      );
 
       // Modal events
       this.bindModalEvents();
@@ -272,13 +269,6 @@
       this.showDeleteConfirmation(serviceId, serviceName);
     }
 
-    handleDuplicateService(e) {
-      e.preventDefault();
-      const $btn = $(e.currentTarget);
-      const serviceId = $btn.data("service-id");
-
-      this.duplicateService(serviceId, $btn);
-    }
 
     // API Methods
     fetchServices(page = 1) {
@@ -358,44 +348,6 @@
       }
     }
 
-    duplicateService(serviceId, $btn) {
-      const originalHtml = $btn.html();
-      $btn
-        .html(
-          '<div class="loading-spinner"><div class="spinner-ring"></div></div> Duplicating...'
-        )
-        .addClass("btn-loading");
-
-      $.ajax({
-        url: mobooking_services_params.ajax_url,
-        type: "POST",
-        data: {
-          action: "mobooking_duplicate_service",
-          nonce: mobooking_services_params.services_nonce,
-          service_id: serviceId,
-        },
-        dataType: "json",
-        success: (response) => {
-          $btn.html(originalHtml).removeClass("btn-loading");
-
-          if (response.success) {
-            this.showFeedback(
-              response.data.message || "Service duplicated successfully."
-            );
-            this.fetchServices(this.currentPage);
-          } else {
-            this.showFeedback(
-              response.data?.message || "Failed to duplicate service.",
-              "error"
-            );
-          }
-        },
-        error: () => {
-          $btn.html(originalHtml).removeClass("btn-loading");
-          this.showFeedback("Network error. Please try again.", "error");
-        },
-      });
-    }
 
     deleteService(serviceId) {
       const $btn = $("#confirm-delete-btn");
@@ -412,7 +364,7 @@
         type: "POST",
         data: {
           action: "mobooking_delete_service",
-          nonce: mobooking_services_params.services_nonce,
+          _ajax_nonce: mobooking_services_params.services_nonce,
           service_id: serviceId,
         },
         dataType: "json",

--- a/classes/Services.php
+++ b/classes/Services.php
@@ -737,7 +737,7 @@ public function handle_get_public_services_ajax() {
     }
 
     public function handle_delete_service_ajax() {
-        if (!check_ajax_referer('mobooking_services_nonce', 'nonce', false)) {
+        if (!check_ajax_referer('mobooking_services_nonce', '_ajax_nonce', false)) {
             wp_send_json_error(['message' => __('Error: Nonce verification failed.', 'mobooking')], 403);
             return;
         }

--- a/dashboard/page-services.php
+++ b/dashboard/page-services.php
@@ -67,23 +67,10 @@ function get_default_service_icon() {
         <!-- Controls Section -->
         <div class="mb-6 p-4 bg-card rounded-lg border">
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div class="relative">
+                <div class="relative md:col-span-3">
                     <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 21-4.3-4.3"/><circle cx="11" cy="11" r="8"/></svg>
                     <input type="text" id="services-search" class="input pl-10" placeholder="<?php esc_attr_e('Search services...', 'mobooking'); ?>" value="">
                 </div>
-                <select id="status-filter" class="select">
-                    <option value=""><?php esc_html_e('All Statuses', 'mobooking'); ?></option>
-                    <option value="active"><?php esc_html_e('Active', 'mobooking'); ?></option>
-                    <option value="inactive"><?php esc_html_e('Inactive', 'mobooking'); ?></option>
-                </select>
-                <select id="sort-filter" class="select">
-                    <option value="name-asc"><?php esc_html_e('Name A-Z', 'mobooking'); ?></option>
-                    <option value="name-desc"><?php esc_html_e('Name Z-A', 'mobooking'); ?></option>
-                    <option value="price-asc"><?php esc_html_e('Price Low-High', 'mobooking'); ?></option>
-                    <option value="price-desc"><?php esc_html_e('Price High-Low', 'mobooking'); ?></option>
-                    <option value="date-asc"><?php esc_html_e('Oldest First', 'mobooking'); ?></option>
-                    <option value="date-desc"><?php esc_html_e('Newest First', 'mobooking'); ?></option>
-                </select>
             </div>
         </div>
         


### PR DESCRIPTION
This commit addresses the remaining issues on the services page:

- **Remove All Filters:** The 'All Statuses' and 'Sort by' dropdown filters have been removed from the services page.
- **Remove Duplicate Button and Associated Logic:** The 'Duplicate' button has been removed from the service cards, and the corresponding JavaScript functions have been removed to eliminate dead code.
- **Fix Delete Service Nonce Error:** The nonce verification error when deleting a service has been resolved by ensuring the nonce is sent and verified with the correct key.