### PR TITLE
fix: Clear choices when changing option type in admin

### DIFF
--- a/assets/js/dashboard-service-edit.js
+++ b/assets/js/dashboard-service-edit.js
@@ -139,12 +139,13 @@ jQuery(function ($) {
           "kilometers",
         ];
 
+        // Always clear choices when the type changes, to avoid mismatched inputs.
+        $choicesList.empty();
+
         if (choiceTypes.includes(type)) {
           $choicesContainer.slideDown(200);
         } else {
           $choicesContainer.slideUp(200);
-          // Clear choices when switching to non-choice type
-          $choicesList.empty();
         }
 
         // Update card selection visually


### PR DESCRIPTION
I've fixed a UI bug in the service edit dashboard. Previously, if you created price ranges for an 'SQM' option and then switched the option type to 'Kilometers', the old range input fields would persist, leading to confusion and incorrect data being saved.

To fix this, I modified the JavaScript event handler for the option type selector. It now clears the list of choices (`.choices-list`) whenever the option type is changed. This ensures a clean state and prevents data mismatch when you switch between different choice-based option types like 'SQM' and 'Kilometers'.