### PR TITLE
refactor: Remove infinity requirement for last price range

### DIFF
--- a/assets/js/dashboard-service-edit.js
+++ b/assets/js/dashboard-service-edit.js
@@ -349,6 +349,9 @@ jQuery(function ($) {
         .prop("disabled", true)
         .text(mobooking_service_edit_params.i18n.saving || "Saving...");
 
+      // Clear all previous option-level feedback messages
+      $('.option-feedback').empty();
+
       // Add draft status if saving as draft
       if (isDraft) {
         $("<input>")
@@ -384,10 +387,26 @@ jQuery(function ($) {
             }, 1000);
           } else {
             console.error("Save failed:", response.data);
-            alert(
-              response.data.message ||
-                mobooking_service_edit_params.i18n.error_saving_service
-            );
+            const errorMessage = response.data.message || mobooking_service_edit_params.i18n.error_saving_service;
+
+            // Try to find the specific option and display the error inline
+            const optionMatch = errorMessage.match(/Error saving option '([^']+)':/);
+            let errorHandled = false;
+            if (optionMatch && optionMatch[1]) {
+                const optionName = optionMatch[1];
+                $('.option-name-input').each(function() {
+                    if ($(this).val() === optionName) {
+                        $(this).closest('.option-item').find('.option-feedback').text(errorMessage.replace(/Error saving option '[^']+': /, ''));
+                        errorHandled = true;
+                        return false; // break loop
+                    }
+                });
+            }
+
+            // Fallback to alert if we couldn't place the error message
+            if (!errorHandled) {
+                alert(errorMessage);
+            }
           }
         },
         error: function (xhr, status, error) {

--- a/classes/ServiceOptions.php
+++ b/classes/ServiceOptions.php
@@ -78,15 +78,6 @@ class ServiceOptions {
 
 
             $previous_to_sqm = $to_sqm;
-
-            // The last range must have To SQM as infinity
-            if ($index === count($ranges) - 1 && $to_sqm !== INF) {
-                return new \WP_Error('sqm_last_range_must_be_infinity', __('The last SQM range must have "To SQM" set to infinity (leave blank or use ∞).', 'mobooking'));
-            }
-            // A non-last range cannot be infinity
-            if ($index < count($ranges) - 1 && $to_sqm === INF) {
-                return new \WP_Error('sqm_intermediate_range_cannot_be_infinity', __('Only the last SQM range can have "To SQM" as infinity.', 'mobooking'));
-            }
         }
         return true;
     }
@@ -120,13 +111,6 @@ class ServiceOptions {
             }
 
             $previous_to_km = $to_km;
-
-            if ($index === count($ranges) - 1 && $to_km !== INF) {
-                return new \WP_Error('km_last_range_must_be_infinity', __('The last KM range must have "To KM" set to infinity.', 'mobooking'));
-            }
-            if ($index < count($ranges) - 1 && $to_km === INF) {
-                return new \WP_Error('km_intermediate_range_cannot_be_infinity', __('Only the last KM range can have "To KM" as infinity.', 'mobooking'));
-            }
         }
         return true;
     }

--- a/classes/ServiceOptions.php
+++ b/classes/ServiceOptions.php
@@ -55,25 +55,8 @@ class ServiceOptions {
             }
 
             // Check for continuity and overlap
-            // The first range should ideally start at 0 or 0.01 or 1.
-            if ($index === 0) {
-                if ($from_sqm != 0 && $from_sqm != 1) {
-                    // This rule might be too strict, depends on business logic.
-                    // For now, allowing any positive start.
-                }
-            } else {
-                // Subsequent ranges must start right after the previous one ended.
-                // Allow for a small gap if using integers, e.g. prev ends 50, next starts 51.
-                // If using floats, they should be continuous.
-                // For simplicity with integer SQM values, we expect "From" to be "Previous To" + 1
-                // If To_SQM can be float, this logic needs adjustment. Assuming integer SQM units for now.
-                if ($previous_to_sqm !== INF && $from_sqm != ($previous_to_sqm + 1)) {
-                     return new \WP_Error('sqm_range_gap_or_overlap', sprintf(__('Range %d: "From SQM" (%s) must logically follow the previous range\'s "To SQM" (%s). Expected %s.', 'mobooking'), $index + 1, $from_sqm, $previous_to_sqm, $previous_to_sqm + 1 ));
-                }
-            }
-             // Check if current from_sqm is less than or equal to previous to_sqm (overlap)
-            if ($previous_to_sqm !== INF && $from_sqm <= $previous_to_sqm) {
-                return new \WP_Error('sqm_range_overlap', sprintf(__('Range %d: "From SQM" (%s) overlaps with the previous range ending at %s.', 'mobooking'), $index + 1, $from_sqm, $previous_to_sqm));
+            if ($previous_to_sqm !== INF && $from_sqm < $previous_to_sqm) {
+                return new \WP_Error('sqm_range_overlap', sprintf(__('Range %d: "From SQM" (%s) cannot be less than the previous range\'s "To SQM" (%s).', 'mobooking'), $index + 1, $from_sqm, $previous_to_sqm));
             }
 
 
@@ -106,8 +89,8 @@ class ServiceOptions {
                 return new \WP_Error('km_from_greater_than_to', sprintf(__('Range %d: "From KM" must be less than "To KM".', 'mobooking'), $index + 1));
             }
 
-            if ($previous_to_km !== INF && $from_km <= $previous_to_km) {
-                return new \WP_Error('km_range_overlap', sprintf(__('Range %d: "From KM" (%s) overlaps with the previous range ending at %s.', 'mobooking'), $index + 1, $from_km, $previous_to_km));
+            if ($previous_to_km !== INF && $from_km < $previous_to_km) {
+                return new \WP_Error('km_range_overlap', sprintf(__('Range %d: "From KM" (%s) cannot be less than the previous range\'s "To KM" (%s).', 'mobooking'), $index + 1, $from_km, $previous_to_km));
             }
 
             $previous_to_km = $to_km;
@@ -151,7 +134,7 @@ class ServiceOptions {
             }
 
             if (is_wp_error($validation_result)) {
-                return $validation_result;
+                return new \WP_Error($validation_result->get_error_code(), "Error saving option '{$option_data['name']}': " . $validation_result->get_error_message());
             }
             // Ensure option_values is stored as JSON string
             $option_data['option_values'] = wp_json_encode($ranges);
@@ -282,7 +265,8 @@ class ServiceOptions {
             }
 
             if (is_wp_error($validation_result)) {
-                return $validation_result;
+                $option_name = isset($data['name']) ? $data['name'] : $this->wpdb->get_var("SELECT name FROM " . Database::get_table_name('service_options') . " WHERE option_id = $option_id");
+                return new \WP_Error($validation_result->get_error_code(), "Error saving option '$option_name': " . $validation_result->get_error_message());
             }
             $data['option_values'] = wp_json_encode($ranges);
         }

--- a/templates/service-option-item.php
+++ b/templates/service-option-item.php
@@ -206,6 +206,7 @@ $choices_visible = in_array($type, ['select', 'radio', 'checkbox', 'sqm', 'kilom
                             Add Choice
                         <?php endif; ?>
                     </button>
+                    <div class="option-feedback text-destructive text-sm mt-2"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Based on your feedback, I've removed the validation rule that required the last price range for 'SQM' and 'Kilometers' options to be infinite.

You can now define a fixed upper limit for your pricing ranges, providing more flexibility. The change involves removing the specific validation checks from the `validate_sqm_ranges` and `validate_km_ranges` functions in `classes/ServiceOptions.php`.