### PR TITLE
feat: Add per-choice pricing for service options

### DIFF
--- a/templates/service-option-item.php
+++ b/templates/service-option-item.php
@@ -18,8 +18,8 @@ $name = $option['name'] ?? 'New Option';
 $description = $option['description'] ?? '';
 $type = $option['type'] ?? 'checkbox';
 $is_required = $option['is_required'] ?? 0;
-$price_type = $option['price_type'] ?? '';
-$price_change = $option['price_change'] ?? '';
+$price_impact_type = $option['price_impact_type'] ?? 'fixed';
+$price_impact_value = $option['price_impact_value'] ?? 0;
 $sort_order = $option['sort_order'] ?? (is_numeric($option_index) ? $option_index + 1 : 0);
 
 // Handle choices - decode if JSON string, otherwise use as array


### PR DESCRIPTION
This commit introduces a flexible pricing system for service options, allowing for more granular control over how options affect the total service price.

Key changes include:

1.  **Per-Choice Pricing:** For options with multiple choices (e.g., Dropdown, Radio), each choice can now have its own price and price type (Fixed, Percentage, Multiply, or No Price). The default price type for new choices is correctly set to "Fixed".

2.  **Option-Level Price Impact:** A new "Price Calculation" setting has been added to each option, allowing it to have a global price impact (e.g., a fixed fee for selecting the option) or to use the new per-choice pricing model.

3.  **UI/UX Improvements:** The service option editor has been updated with a more intuitive and well-designed interface for managing these new pricing settings. This includes interactive cards for selecting the price impact type and a clean layout for defining choices and their prices.

4.  **Restored Functionality:** The UI for managing range-based pricing for `sqm` (square meter) and `kilometers` option types has been restored, fixing a regression from a previous version.

5.  **Backend Refactoring:** The `ServiceOptions` class has been significantly refactored for better maintainability and clarity. A new `prepare_option_data` method centralizes validation and data preparation, and the `add` and `update` methods have been simplified.