### PR TITLE
Fix: Ensure new bookings are linked to customer records

### DIFF
--- a/classes/Bookings.php
+++ b/classes/Bookings.php
@@ -578,7 +578,16 @@ foreach ($calculated_service_items as $service_item) {
                     error_log("MoBooking: Error updating customer stats: " . $e->getMessage());
                 }
             }
-            $booking_data['mob_customer_id'] = is_wp_error($mob_customer_id) ? null : $mob_customer_id;
+
+            if (!is_wp_error($mob_customer_id) && $mob_customer_id > 0) {
+                $this->wpdb->update(
+                    $bookings_table,
+                    ['mob_customer_id' => $mob_customer_id],
+                    ['booking_id' => $new_booking_id],
+                    ['%d'],
+                    ['%d']
+                );
+            }
 
             // Update discount usage
             if ($validated_discount_info && isset($validated_discount_info['discount_id'])) {


### PR DESCRIPTION
Previously, when a new booking was created, the system would correctly create or update a customer record and retrieve the customer ID. However, this customer ID was not being saved to the booking record in the database.

This change adds a database UPDATE query to the booking creation process. After a new booking is inserted and the customer ID is retrieved, this query updates the `mob_customer_id` field in the `bookings` table, correctly linking the booking to the customer.