### PR TITLE
Fix: Correctly parse services from AJAX response

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1013,7 +1013,10 @@ function mobooking_unified_get_services() {
         ), ARRAY_A);
 
         if (empty($services)) {
-            wp_send_json_error(['message' => 'No services available'], 404);
+            wp_send_json_success([
+                'services' => [],
+                'count' => 0
+            ]);
             return;
         }
 

--- a/templates/booking-form-public.php
+++ b/templates/booking-form-public.php
@@ -1651,7 +1651,7 @@ function loadServices() {
     if (!container) return;
     
     const data = new FormData();
-    data.append('action', 'mobooking_get_services');
+    data.append('action', 'mobooking_get_public_services');
     data.append('nonce', MoBookingConfig.nonce);
     data.append('tenant_id', MoBookingConfig.tenant_id);
     
@@ -1661,8 +1661,8 @@ function loadServices() {
     })
     .then(response => response.json())
     .then(result => {
-        if (result.success && result.data) {
-            renderServices(result.data);
+        if (result.success && result.data && typeof result.data.services !== 'undefined') {
+            renderServices(result.data.services);
         } else {
             container.innerHTML = `
                 <div class="mobooking-feedback error" style="display: block;">


### PR DESCRIPTION
The booking form was not displaying services because the frontend was not correctly parsing the AJAX response. The `renderServices` function was being called with the entire data object, instead of the `services` array within that object.

This commit updates the `loadServices` function in `templates/booking-form-public.php` to pass `result.data.services` to the `renderServices` function. This ensures that the services are correctly rendered on the page.