### PR TITLE
Fix: Gracefully handle no services in booking form

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1184,7 +1184,11 @@ function mobooking_override_handler() {
     ), ARRAY_A);
 
     if (empty($services)) {
-        wp_send_json_error(['message' => 'No services available']);
+        wp_send_json_success([
+            'services' => [],
+            'count' => 0
+        ]);
+        return;
     }
 
     $formatted_services = [];


### PR DESCRIPTION
This commit addresses the issue where the booking form was not displaying services correctly when no services were available. The problem was twofold:

1.  The backend AJAX handler (`mobooking_override_handler` in `functions.php`) was returning a JSON error when no services were found. This has been corrected to return a success response with an empty `services` array.
2.  The frontend JavaScript in `templates/booking-form-public.php` was not correctly parsing the `services` array from the AJAX response. This has been updated to correctly access `result.data.services`.

These changes ensure that the booking form now correctly displays the 'No services available at this time.' message without any errors.