### PR TITLE
Redesign services card to match dashboard design

### DIFF
--- a/assets/css/dashboard-services-redesigned.css
+++ b/assets/css/dashboard-services-redesigned.css
@@ -1,0 +1,323 @@
+/* ============================================================================
+   MoBooking Service Card Redesign CSS
+   Inspired by the modern shadcn/ui styling of the dashboard
+   ============================================================================ */
+
+/* ============================================================================
+   CSS Variables - Copied from dashboard-overview-enhanced.css for consistency
+   ============================================================================ */
+:root {
+  /* Light theme colors */
+  --mobk-background: 0 0% 100%;
+  --mobk-foreground: 222.2 84% 4.9%;
+  --mobk-card: 0 0% 100%;
+  --mobk-card-foreground: 222.2 84% 4.9%;
+  --mobk-popover: 0 0% 100%;
+  --mobk-popover-foreground: 222.2 84% 4.9%;
+  --mobk-primary: 221.2 83.2% 53.3%;
+  --mobk-primary-foreground: 210 40% 98%;
+  --mobk-secondary: 210 40% 96.1%;
+  --mobk-secondary-foreground: 222.2 84% 4.9%;
+  --mobk-muted: 210 40% 96.1%;
+  --mobk-muted-foreground: 215.4 16.3% 46.9%;
+  --mobk-accent: 210 40% 96.1%;
+  --mobk-accent-foreground: 222.2 84% 4.9%;
+  --mobk-destructive: 0 84.2% 60.2%;
+  --mobk-destructive-foreground: 210 40% 98%;
+  --mobk-border: 214.3 31.8% 91.4%;
+  --mobk-input: 214.3 31.8% 91.4%;
+  --mobk-ring: 221.2 83.2% 53.3%;
+  --mobk-radius: 0.75rem; /* Slightly larger radius for a more modern feel */
+  --mobk-success: 142.1 76.2% 36.3%;
+  --mobk-badge-bg-active: #D1FAE5;
+  --mobk-badge-text-active: #065F46;
+  --mobk-badge-bg-inactive: #F3F4F6;
+  --mobk-badge-text-inactive: #4B5563;
+
+
+  /* Shadows */
+  --mobk-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --mobk-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --mobk-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1),
+    0 2px 4px -2px rgb(0 0 0 / 0.1);
+
+  /* Animation */
+  --mobk-duration-fast: 150ms;
+  --mobk-duration-normal: 200ms;
+}
+
+/* Dark theme support */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --mobk-background: 222.2 84% 4.9%;
+    --mobk-foreground: 210 40% 98%;
+    --mobk-card: 222.2 84% 4.9%;
+    --mobk-card-foreground: 210 40% 98%;
+    --mobk-border: 217.2 32.6% 17.5%;
+    --mobk-muted: 217.2 32.6% 17.5%;
+    --mobk-muted-foreground: 215 20.2% 65.1%;
+    --mobk-badge-bg-active: #064E3B;
+    --mobk-badge-text-active: #A7F3D0;
+    --mobk-badge-bg-inactive: #374151;
+    --mobk-badge-text-inactive: #D1D5DB;
+  }
+}
+
+
+/* ============================================================================
+   Service Card Component
+   ============================================================================ */
+
+.service-card {
+    background: hsl(var(--mobk-card));
+    border: 1px solid hsl(var(--mobk-border));
+    border-radius: var(--mobk-radius);
+    box-shadow: var(--mobk-shadow-sm);
+    transition: all var(--mobk-duration-normal) ease;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    height: 100%; /* Ensure cards in a row are same height */
+}
+
+.service-card:hover {
+    box-shadow: var(--mobk-shadow-md);
+    transform: translateY(-2px);
+}
+
+/* Card Image Section */
+.service-card__image-wrapper {
+    position: relative;
+    height: 180px; /* Fixed height for the image area */
+    background-color: hsl(var(--mobk-muted));
+}
+
+.service-card__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.service-card__image-placeholder {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: hsl(var(--mobk-muted-foreground));
+}
+
+.service-card__image-placeholder svg {
+    width: 3rem;
+    height: 3rem;
+}
+
+.service-card__status-badge {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: capitalize;
+    border: 1px solid hsl(var(--mobk-border) / 0.5);
+}
+
+.service-card__status-badge.status-active {
+    background-color: var(--mobk-badge-bg-active);
+    color: var(--mobk-badge-text-active);
+}
+
+.service-card__status-badge.status-inactive {
+    background-color: var(--mobk-badge-bg-inactive);
+    color: var(--mobk-badge-text-inactive);
+}
+
+/* Card Content Section */
+.service-card__content {
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1; /* Allows content to fill space */
+}
+
+.service-card__header {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+    align-items: flex-start;
+}
+
+.service-card__icon {
+    flex-shrink: 0;
+    color: hsl(var(--mobk-primary));
+}
+
+.service-card__icon svg {
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+.service-card__title-wrapper {
+    flex-grow: 1;
+}
+
+.service-card__title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: hsl(var(--mobk-card-foreground));
+    margin: 0 0 0.25rem 0;
+    line-height: 1.3;
+}
+
+.service-card__price {
+    font-size: 1rem;
+    font-weight: 700;
+    color: hsl(var(--mobk-primary));
+}
+
+.service-card__description {
+    font-size: 0.875rem;
+    color: hsl(var(--mobk-muted-foreground));
+    margin-bottom: 1rem;
+    flex-grow: 1; /* Pushes meta and footer down */
+    line-height: 1.5;
+    /* Clamp to 3 lines */
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.service-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    font-size: 0.8rem;
+    color: hsl(var(--mobk-muted-foreground));
+    padding-top: 1rem;
+    border-top: 1px solid hsl(var(--mobk-border));
+    margin-top: auto; /* Pushes itself to the bottom */
+}
+
+.service-card__meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+}
+
+.service-card__meta-item svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+/* Card Footer Section */
+.service-card__footer {
+    padding: 1rem;
+    border-top: 1px solid hsl(var(--mobk-border));
+    display: flex;
+    gap: 0.75rem;
+    background-color: hsl(var(--mobk-muted) / 0.3);
+}
+
+/* Button Styles - Reused from dashboard */
+.service-card__footer .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    font-weight: 500;
+    text-decoration: none;
+    transition: all 0.2s;
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-size: 0.875rem;
+}
+
+.service-card__footer .btn-primary {
+    background-color: hsl(var(--mobk-primary));
+    color: hsl(var(--mobk-primary-foreground));
+    flex-grow: 1; /* Make primary button take more space */
+}
+
+.service-card__footer .btn-primary:hover {
+    opacity: 0.9;
+}
+
+.service-card__footer .btn-destructive {
+    background-color: transparent;
+    color: hsl(var(--mobk-destructive));
+    border: 1px solid hsl(var(--mobk-destructive));
+    padding: 0.5rem; /* Make it a square icon button */
+}
+
+.service-card__footer .btn-destructive:hover {
+    background-color: hsl(var(--mobk-destructive));
+    color: hsl(var(--mobk-destructive-foreground));
+}
+
+.service-card__footer .btn svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+.service-card__footer .btn-primary svg {
+    margin-right: 0.5rem;
+}
+
+/* Grid container adjustments if necessary */
+.mobooking-services-page-wrapper .grid {
+    align-items: stretch; /* Make grid items stretch to fill height */
+}
+
+/* ============================================================================
+   Responsive Design
+   ============================================================================ */
+
+@media (max-width: 768px) {
+    .service-card__image-wrapper {
+        height: 160px; /* Slightly smaller image on tablets */
+    }
+
+    .service-card__title {
+        font-size: 1rem;
+    }
+
+    .service-card__price {
+        font-size: 0.9rem;
+    }
+
+    .service-card__content,
+    .service-card__footer {
+        padding: 0.75rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .service-card__image-wrapper {
+        height: 140px; /* Even smaller for mobile */
+    }
+
+    .service-card__header {
+        gap: 0.5rem;
+    }
+
+    .service-card__icon svg {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    .service-card__title {
+        font-size: 0.9rem;
+    }
+
+    .service-card__description {
+        font-size: 0.8rem;
+    }
+
+    .service-card__meta {
+        gap: 0.75rem;
+    }
+}

--- a/dashboard/page-services.php
+++ b/dashboard/page-services.php
@@ -93,64 +93,64 @@ function get_default_service_icon() {
                     </div>
                 <?php else: ?>
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" id="services-grid">
-                        <?php foreach ($services_list as $service): 
-                            $price_formatted = format_currency($service['price'], $currency_symbol, $currency_pos);
-                            $service_icon = !empty($service['icon']) 
-                                ? $services_manager->get_service_icon_html($service['icon'])
-                                : get_default_service_icon();
-                            $options_count = !empty($service['options']) ? count($service['options']) : 0;
-                        ?>
-                            <div class="card" data-service-id="<?php echo esc_attr($service['service_id']); ?>">
-                                <div class="card-header p-0 relative">
-                                    <?php if (!empty($service['image_url'])): ?>
-                                        <img src="<?php echo esc_url($service['image_url']); ?>" alt="<?php echo esc_attr($service['name']); ?>" class="w-full h-48 object-cover">
-                                    <?php else: ?>
-                                        <div class="w-full h-48 bg-muted flex items-center justify-center">
-                                            <svg class="w-12 h-12 text-muted-foreground" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
-                                        </div>
-                                    <?php endif; ?>
-                                    <div class="badge badge-<?php echo esc_attr($service['status']); ?> absolute top-2 right-2"><?php echo esc_html(ucfirst($service['status'])); ?></div>
-                                </div>
-                                <div class="card-content p-4">
-                                    <div class="flex items-start gap-4 mb-4">
-                                        <div class="text-primary"><?php echo $service_icon; ?></div>
-                                        <div>
-                                            <h3 class="font-semibold"><?php echo esc_html($service['name']); ?></h3>
-                                            <p class="text-primary font-bold"><?php echo esc_html($price_formatted); ?></p>
-                                        </div>
+                    <?php foreach ($services_list as $service):
+                        $price_formatted = format_currency($service['price'], $currency_symbol, $currency_pos);
+                        $service_icon = !empty($service['icon'])
+                            ? $services_manager->get_service_icon_html($service['icon'])
+                            : get_default_service_icon();
+                        $options_count = !empty($service['options']) ? count($service['options']) : 0;
+                    ?>
+                        <div class="service-card" data-service-id="<?php echo esc_attr($service['service_id']); ?>">
+                            <div class="service-card__image-wrapper">
+                                <?php if (!empty($service['image_url'])): ?>
+                                    <img src="<?php echo esc_url($service['image_url']); ?>" alt="<?php echo esc_attr($service['name']); ?>" class="service-card__image">
+                                <?php else: ?>
+                                    <div class="service-card__image-placeholder">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
                                     </div>
-                                    <?php if (!empty($service['description'])): ?>
-                                        <p class="text-sm text-muted-foreground mb-4 line-clamp-3"><?php echo esc_html($service['description']); ?></p>
-                                    <?php endif; ?>
-                                    <div class="text-xs text-muted-foreground space-y-2">
-                                        <div class="flex items-center gap-2">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-                                            <span><?php echo esc_html($service['duration']); ?> <?php esc_html_e('min', 'mobooking'); ?></span>
-                                        </div>
-                                        <?php if ($options_count > 0): ?>
-                                        <div class="flex items-center gap-2">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><path d="M9 12l2 2 4-4"/><path d="M21 12c.552 0 1-.448 1-1V5c0-.552-.448-1-1-1H3c-.552 0-1 .448-1 1v6c0 .552.448 1 1 1h18z"/></svg>
-                                            <span><?php echo esc_html($options_count); ?> <?php esc_html_e('Options', 'mobooking'); ?></span>
-                                        </div>
-                                        <?php endif; ?>
+                                <?php endif; ?>
+                                <div class="service-card__status-badge status-<?php echo esc_attr($service['status']); ?>"><?php echo esc_html(ucfirst($service['status'])); ?></div>
+                            </div>
+                            <div class="service-card__content">
+                                <div class="service-card__header">
+                                    <div class="service-card__icon"><?php echo $service_icon; ?></div>
+                                    <div class="service-card__title-wrapper">
+                                        <h3 class="service-card__title"><?php echo esc_html($service['name']); ?></h3>
+                                        <p class="service-card__price"><?php echo esc_html($price_formatted); ?></p>
                                     </div>
                                 </div>
-                                <div class="card-footer p-4 flex gap-2">
-                                    <a href="<?php echo esc_url(site_url('/dashboard/service-edit/?service_id=' . $service['service_id'])); ?>" class="btn btn-primary w-full">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mr-2"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
-                                        <?php esc_html_e('View', 'mobooking'); ?>
-                                    </a>
-                                    <form method="POST" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" data-service-name="<?php echo esc_attr($service['name']); ?>">
-                                        <input type="hidden" name="action" value="mobooking_delete_service">
-                                        <input type="hidden" name="service_id" value="<?php echo esc_attr($service['service_id']); ?>">
-                                        <?php wp_nonce_field('mobooking_delete_service_nonce'); ?>
-                                        <button type="submit" class="btn btn-destructive">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
-                                        </button>
-                                    </form>
+                                <?php if (!empty($service['description'])): ?>
+                                    <p class="service-card__description"><?php echo esc_html($service['description']); ?></p>
+                                <?php endif; ?>
+                                <div class="service-card__meta">
+                                    <div class="service-card__meta-item">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                                        <span><?php echo esc_html($service['duration']); ?> <?php esc_html_e('min', 'mobooking'); ?></span>
+                                    </div>
+                                    <?php if ($options_count > 0): ?>
+                                    <div class="service-card__meta-item">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12l2 2 4-4"/><path d="M21 12c.552 0 1-.448 1-1V5c0-.552-.448-1-1-1H3c-.552 0-1 .448-1 1v6c0 .552.448 1 1 1h18z"/></svg>
+                                        <span><?php echo esc_html($options_count); ?> <?php esc_html_e('Options', 'mobooking'); ?></span>
+                                    </div>
+                                    <?php endif; ?>
                                 </div>
                             </div>
-                        <?php endforeach; ?>
+                            <div class="service-card__footer">
+                                <a href="<?php echo esc_url(site_url('/dashboard/service-edit/?service_id=' . $service['service_id'])); ?>" class="btn btn-primary">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
+                                    <?php esc_html_e('View', 'mobooking'); ?>
+                                </a>
+                                <form method="POST" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" data-service-name="<?php echo esc_attr($service['name']); ?>">
+                                    <input type="hidden" name="action" value="mobooking_delete_service">
+                                    <input type="hidden" name="service_id" value="<?php echo esc_attr($service['service_id']); ?>">
+                                    <?php wp_nonce_field('mobooking_delete_service_nonce'); ?>
+                                    <button type="submit" class="btn btn-destructive">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
                     </div>
                     <?php if ($total_pages > 1): ?>
                         <div class="flex justify-center mt-6">

--- a/functions/theme-setup.php
+++ b/functions/theme-setup.php
@@ -337,6 +337,7 @@ if ( is_page_template('templates/booking-form-public.php') || $page_type_for_scr
         ]);
 
         if ( $current_page_slug === 'services' ) {
+            wp_enqueue_style('mobooking-dashboard-services-redesigned', MOBOOKING_THEME_URI . 'assets/css/dashboard-services-redesigned.css', array('mobooking-dashboard-main'), MOBOOKING_VERSION);
             wp_enqueue_script('mobooking-dashboard-services', MOBOOKING_THEME_URI . 'assets/js/dashboard-services.js', array('jquery'), MOBOOKING_VERSION, true);
             wp_localize_script('mobooking-dashboard-services', 'mobooking_services_params', [
                 'ajax_url' => admin_url('admin-ajax.php'),


### PR DESCRIPTION
This commit redesigns the services card on the dashboard to align with the modern, shadcn/ui-inspired design language of the rest of the dashboard.

Key changes:
- Created a new stylesheet `assets/css/dashboard-services-redesigned.css` with styles for the new card, including CSS variables for consistency, dark mode support, and responsive media queries.
- Refactored the HTML structure of the service card in `dashboard/page-services.php` to use a more semantic, BEM-style class structure (`service-card`, `service-card__content`, etc.).
- Enqueued the new stylesheet in `functions/theme-setup.php` to ensure it's loaded on the services page.
- The new card design is fully responsive and adapts to different screen sizes.