### PR TITLE
Refactor: Redesign service edit page to match dashboard style

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -1143,3 +1143,49 @@ a.quick-action:hover {
     top: 2rem; /* Adjust as needed */
   }
 }
+
+.service-icon-section {
+    border-top: 1px solid hsl(var(--border));
+    padding-top: 1.5rem;
+    margin-top: 1.5rem;
+}
+
+.mobooking-option-item {
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    margin-bottom: 1rem;
+}
+
+.mobooking-option-header {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    background-color: hsl(var(--muted));
+}
+
+.mobooking-option-drag-handle {
+    margin-right: 0.75rem;
+    color: hsl(var(--muted-foreground));
+    cursor: grab;
+}
+
+.mobooking-option-summary {
+    flex-grow: 1;
+}
+
+.mobooking-option-name {
+    font-weight: 600;
+    margin: 0;
+}
+
+.mobooking-option-badges {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+}
+
+.mobooking-option-content {
+    padding: 1.5rem;
+    border-top: 1px solid hsl(var(--border));
+}

--- a/assets/js/dashboard-service-edit.js
+++ b/assets/js/dashboard-service-edit.js
@@ -5,7 +5,6 @@ jQuery(function ($) {
 
     init: function () {
       this.bindEvents();
-      this.initTabs();
       this.initSwitches();
       this.initExistingOptions(); // NEW: Initialize existing options properly
     },
@@ -49,12 +48,8 @@ jQuery(function ($) {
         self.saveService();
       });
 
-      // Save as draft
-      $("#save-draft-btn").on("click", () => this.saveService(true));
-
-      // Delete and duplicate
+      // Delete
       $("#delete-service-btn").on("click", () => this.deleteService());
-      $("#duplicate-service-btn").on("click", () => this.duplicateService());
 
       // Icon and image handling
       $("#select-icon-btn").on("click", () => this.openIconSelector());
@@ -228,18 +223,6 @@ jQuery(function ($) {
       });
     },
 
-    initTabs: function () {
-      $(".tabs-trigger").on("click", function () {
-        const tabId = $(this).data("tab");
-
-        $(".tabs-trigger").removeClass("active").attr("aria-selected", "false");
-        $(this).addClass("active").attr("aria-selected", "true");
-
-        $(".tabs-content").removeClass("active");
-        $("#" + tabId).addClass("active");
-      });
-    },
-
     initSwitches: function () {
       $(document).on("click", ".switch", function () {
         const $switchEl = $(this);
@@ -336,19 +319,6 @@ jQuery(function ($) {
                 </div>
             `;
       $("#options-container").html(emptyStateHtml);
-    },
-
-    updateOptionsBadge: function () {
-      const count = $(".option-item").length;
-      const $badge = $('.tabs-trigger[data-tab="service-options"] .badge');
-
-      if ($badge.length) {
-        $badge.text(count);
-      } else if (count > 0) {
-        $('.tabs-trigger[data-tab="service-options"]').append(
-          `<span class="badge badge-secondary">${count}</span>`
-        );
-      }
     },
 
     displaySaveError: function(errorMessage) {

--- a/dashboard/page-service-edit.php
+++ b/dashboard/page-service-edit.php
@@ -184,11 +184,11 @@ if ( $edit_mode && $service_id > 0 ) {
 			</div>
 		</div>
 		<div class="mobooking-page-header-actions">
+			<a href="<?php echo esc_url( $breadcrumb_services ); ?>" class="btn btn-secondary btn-sm">
+				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
+				<?php esc_html_e( 'Back', 'mobooking' ); ?>
+			</a>
 			<?php if ( $edit_mode ) : ?>
-				<button type="button" id="duplicate-service-btn" class="btn btn-secondary btn-sm">
-					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
-					<?php esc_html_e( 'Duplicate', 'mobooking' ); ?>
-				</button>
 				<button type="button" id="delete-service-btn" class="btn btn-destructive btn-sm">
 					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><path d="m19 6-1 14H6L5 6"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
 					<?php esc_html_e( 'Delete', 'mobooking' ); ?>
@@ -225,7 +225,7 @@ if ( $edit_mode && $service_id > 0 ) {
 					</div>
 					<div class="mobooking-card-content space-y-4">
 						<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-							<div class="md:col-span-2">
+							<div class="md:col-span-3">
 								<label class="mobooking-filter-item label" for="service-name">
 									<?php esc_html_e( 'Service Name', 'mobooking' ); ?> <span class="text-destructive">*</span>
 								</label>
@@ -238,18 +238,6 @@ if ( $edit_mode && $service_id > 0 ) {
 									value="<?php echo esc_attr( $service_name ); ?>"
 									required
 								>
-							</div>
-							<div>
-								<label class="mobooking-filter-item label"><?php esc_html_e( 'Status', 'mobooking' ); ?></label>
-								<div class="flex items-center space-x-2 mt-2">
-									<button type="button" class="switch <?php echo 'active' === $service_status ? 'switch-checked' : ''; ?>" data-switch="status">
-										<span class="switch-thumb"></span>
-									</button>
-									<span class="text-sm font-medium">
-										<?php echo 'active' === $service_status ? esc_html__( 'Active', 'mobooking' ) : esc_html__( 'Inactive', 'mobooking' ); ?>
-									</span>
-									<input type="hidden" name="status" value="<?php echo esc_attr( $service_status ); ?>">
-								</div>
 							</div>
 						</div>
 
@@ -361,33 +349,35 @@ if ( $edit_mode && $service_id > 0 ) {
 			</div>
 
 			<div class="mobooking-sidebar">
+				<!-- Actions Card -->
+				<div class="mobooking-card">
+					<div class="mobooking-card-header">
+						<h3 class="mobooking-card-title"><?php esc_html_e( 'Actions', 'mobooking' ); ?></h3>
+					</div>
+					<div class="mobooking-card-content">
+						<button type="submit" class="btn btn-primary w-full" id="save-service-btn">
+							<?php echo $edit_mode ? esc_html__( 'Update Service', 'mobooking' ) : esc_html__( 'Create Service', 'mobooking' ); ?>
+						</button>
+						<div class="flex items-center justify-between mt-4">
+							<label class="mobooking-filter-item label"><?php esc_html_e( 'Status', 'mobooking' ); ?></label>
+							<div class="flex items-center space-x-2">
+								<button type="button" class="switch <?php echo 'active' === $service_status ? 'switch-checked' : ''; ?>" data-switch="status">
+									<span class="switch-thumb"></span>
+								</button>
+								<span class="text-sm font-medium">
+									<?php echo 'active' === $service_status ? esc_html__( 'Active', 'mobooking' ) : esc_html__( 'Inactive', 'mobooking' ); ?>
+								</span>
+								<input type="hidden" name="status" value="<?php echo esc_attr( $service_status ); ?>">
+							</div>
+						</div>
+					</div>
+				</div>
 				<!-- Visual Settings Card -->
 				<div class="mobooking-card">
 					<div class="mobooking-card-header">
 						<h3 class="mobooking-card-title"><?php esc_html_e( 'Visuals', 'mobooking' ); ?></h3>
 					</div>
 					<div class="mobooking-card-content space-y-6">
-						<!-- Service Icon -->
-						<div>
-							<label class="mobooking-filter-item label"><?php esc_html_e( 'Service Icon', 'mobooking' ); ?></label>
-							<div class="mobooking-icon-selector">
-								<div class="mobooking-icon-preview">
-									<div id="current-icon" class="mobooking-icon-display">
-										<?php if ( ! empty( $service_icon ) ) : ?>
-											<?php echo wp_kses_post( $service_icon ); ?>
-										<?php else : ?>
-											<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27,6.96 12,12.01 20.73,6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
-										<?php endif; ?>
-									</div>
-								</div>
-								<button type="button" id="select-icon-btn" class="btn btn-outline btn-sm mt-2">
-									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1 1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-									<?php esc_html_e( 'Choose Icon', 'mobooking' ); ?>
-								</button>
-								<input type="hidden" id="service-icon" name="icon" value="<?php echo esc_attr( $service_icon ); ?>">
-							</div>
-						</div>
-
 						<!-- Service Image -->
 						<div>
 							<label class="mobooking-filter-item label"><?php esc_html_e( 'Service Image', 'mobooking' ); ?></label>
@@ -410,33 +400,31 @@ if ( $edit_mode && $service_id > 0 ) {
 								<input type="hidden" id="service-image-url" name="image_url" value="<?php echo esc_attr( $service_image_url ); ?>">
 							</div>
 						</div>
+						<!-- Service Icon -->
+						<div class="service-icon-section">
+							<label class="mobooking-filter-item label"><?php esc_html_e( 'Service Icon', 'mobooking' ); ?></label>
+							<div class="mobooking-icon-selector">
+								<div class="mobooking-icon-preview">
+									<div id="current-icon" class="mobooking-icon-display">
+										<?php if ( ! empty( $service_icon ) ) : ?>
+											<?php echo wp_kses_post( $service_icon ); ?>
+										<?php else : ?>
+											<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27,6.96 12,12.01 20.73,6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
+										<?php endif; ?>
+									</div>
+								</div>
+								<button type="button" id="select-icon-btn" class="btn btn-outline btn-sm mt-2">
+									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1 1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+									<?php esc_html_e( 'Choose Icon', 'mobooking' ); ?>
+								</button>
+								<input type="hidden" id="service-icon" name="icon" value="<?php echo esc_attr( $service_icon ); ?>">
+							</div>
+						</div>
 					</div>
 				</div>
 			</div>
 		</div>
 
-		<!-- Action Bar -->
-		<div class="action-bar">
-			<div class="action-bar-content">
-				<div class="flex items-center justify-between">
-					<a href="<?php echo esc_url( $breadcrumb_services ); ?>" class="btn btn-ghost">
-						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
-						<?php esc_html_e( 'Cancel', 'mobooking' ); ?>
-					</a>
-
-					<div class="flex gap-2">
-						<button type="button" class="btn btn-outline" id="save-draft-btn">
-							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14,2 14,8 20,8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10,9 9,9 8,9"/></svg>
-							<?php esc_html_e( 'Save as Draft', 'mobooking' ); ?>
-						</button>
-						<button type="submit" class="btn btn-primary" id="save-service-btn">
-							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 12 2 2 4-4"/><path d="M21 12c.552 0 1-.448 1-1V5a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v6c0 .552.448 1 1 1h18z"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-7"/></svg>
-							<?php echo $edit_mode ? esc_html__( 'Update Service', 'mobooking' ) : esc_html__( 'Create Service', 'mobooking' ); ?>
-						</button>
-					</div>
-				</div>
-			</div>
-		</div>
 	</form>
 </div>
 

--- a/templates/service-option-item.php
+++ b/templates/service-option-item.php
@@ -45,26 +45,26 @@ if (isset($option['choices'])) {
 $choices_visible = in_array($type, ['select', 'radio', 'checkbox']);
 
 ?>
-<div class="option-item" data-option-index="<?php echo esc_attr($option_index); ?>">
-    <div class="option-header">
-        <div class="drag-handle">
+<div class="mobooking-option-item" data-option-index="<?php echo esc_attr($option_index); ?>">
+    <div class="mobooking-option-header">
+        <div class="mobooking-option-drag-handle">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/>
                 <circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/>
             </svg>
         </div>
-        <div class="option-summary">
-            <h4 class="option-name"><?php echo esc_html($name); ?></h4>
-            <div class="option-badges">
+        <div class="mobooking-option-summary">
+            <h4 class="mobooking-option-name"><?php echo esc_html($name); ?></h4>
+            <div class="mobooking-option-badges">
                 <span class="badge badge-outline"><?php echo esc_html($option_types[$type]['label'] ?? 'Unknown'); ?></span>
-                <?php if (!empty($price_type) && $price_type !== ''): ?>
+                <?php if (!empty($price_impact_type) && $price_impact_type !== ''): ?>
                     <span class="badge badge-accent">
-                        <?php echo esc_html($price_types[$price_type]['label'] ?? 'Price'); ?>
+                        <?php echo esc_html($price_impact_types[$price_impact_type]['label'] ?? 'Price'); ?>
                     </span>
                 <?php endif; ?>
             </div>
         </div>
-        <div class="option-actions">
+        <div class="mobooking-option-actions">
             <button type="button" class="btn-icon toggle-option">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="m6 9 6 6 6-6"/>
@@ -77,27 +77,27 @@ $choices_visible = in_array($type, ['select', 'radio', 'checkbox']);
             </button>
         </div>
     </div>
-    <div class="option-content" style="display: none;">
+    <div class="mobooking-option-content" style="display: none;">
         <input type="hidden" name="options[<?php echo esc_attr($option_index); ?>][option_id]" value="<?php echo esc_attr($option_id); ?>">
         <input type="hidden" name="options[<?php echo esc_attr($option_index); ?>][sort_order]" value="<?php echo esc_attr($sort_order); ?>" class="option-sort-order">
 
         <div class="space-y-4">
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="md:col-span-2">
-                    <label class="form-label">
+                    <label class="mobooking-filter-item label">
                         Option Name <span class="text-destructive">*</span>
                     </label>
                     <input
                         type="text"
                         name="options[<?php echo esc_attr($option_index); ?>][name]"
-                        class="form-input option-name-input"
+                        class="regular-text option-name-input"
                         placeholder="e.g., Room Size"
                         value="<?php echo esc_attr($name); ?>"
                         required
                     >
                 </div>
                 <div>
-                    <label class="form-label">Required</label>
+                    <label class="mobooking-filter-item label">Required</label>
                     <div class="flex items-center space-x-2 mt-2">
                         <button type="button" class="switch <?php echo $is_required ? 'switch-checked' : ''; ?>" data-switch="required">
                             <span class="switch-thumb"></span>
@@ -109,10 +109,10 @@ $choices_visible = in_array($type, ['select', 'radio', 'checkbox']);
             </div>
 
             <div>
-                <label class="form-label">Description</label>
+                <label class="mobooking-filter-item label">Description</label>
                 <textarea
                     name="options[<?php echo esc_attr($option_index); ?>][description]"
-                    class="form-textarea"
+                    class="regular-text"
                     rows="2"
                     placeholder="Helpful description for customers..."
                 ><?php echo esc_textarea($description); ?></textarea>
@@ -121,7 +121,7 @@ $choices_visible = in_array($type, ['select', 'radio', 'checkbox']);
             <hr>
 
             <div>
-                <label class="form-label price-impact-label">
+                <label class="mobooking-filter-item label price-impact-label">
                     <?php if ($type === 'sqm'): ?>
                         <?php esc_html_e('Price per Square Meter', 'mobooking'); ?>
                     <?php elseif ($type === 'kilometers'): ?>
@@ -152,7 +152,7 @@ $choices_visible = in_array($type, ['select', 'radio', 'checkbox']);
                  <?php endif; ?>
 
                 <div class="price-impact-value-container mt-3" style="display: <?php echo !empty($price_impact_type) || in_array($type, ['sqm', 'kilometers']) ? 'block' : 'none'; ?>;">
-                    <label class="form-label" for="price-impact-value-<?php echo esc_attr($option_index); ?>">
+                    <label class="mobooking-filter-item label" for="price-impact-value-<?php echo esc_attr($option_index); ?>">
                         <?php if ($type === 'sqm'): ?>
                             <?php esc_html_e('Price per Square Meter', 'mobooking'); ?>
                         <?php elseif ($type === 'kilometers'): ?>
@@ -165,7 +165,7 @@ $choices_visible = in_array($type, ['select', 'radio', 'checkbox']);
                         type="number"
                         id="price-impact-value-<?php echo esc_attr($option_index); ?>"
                         name="options[<?php echo esc_attr($option_index); ?>][price_impact_value]"
-                        class="form-input"
+                        class="regular-text"
                         placeholder="e.g., 10.00"
                         value="<?php echo esc_attr($price_impact_value); ?>"
                         step="0.01"
@@ -176,7 +176,7 @@ $choices_visible = in_array($type, ['select', 'radio', 'checkbox']);
             <hr>
 
             <div>
-                <label class="form-label">Option Type</label>
+                <label class="mobooking-filter-item label">Option Type</label>
                 <p class="form-description text-xs mb-2">Select how the user will interact with this option.</p>
                 <div class="option-types-grid">
                     <?php foreach ($option_types as $type_key => $type_data): ?>
@@ -198,7 +198,7 @@ $choices_visible = in_array($type, ['select', 'radio', 'checkbox']);
             <div class="choices-container" style="display: <?php echo $choices_visible ? 'block' : 'none'; ?>;">
                 <hr>
                 <div class="mt-4">
-                    <label class="form-label">
+                    <label class="mobooking-filter-item label">
                         Choices
                     </label>
                     <p class="form-description text-xs mb-2">
@@ -209,8 +209,8 @@ $choices_visible = in_array($type, ['select', 'radio', 'checkbox']);
                             <?php foreach ($choices as $choice_index => $choice): ?>
 
                                     <div class="choice-item flex items-center gap-2">
-                                        <input type="text" name="options[<?php echo esc_attr($option_index); ?>][choices][<?php echo $choice_index; ?>][label]" class="form-input flex-1" placeholder="Choice Label" value="<?php echo esc_attr($choice['label'] ?? $choice); ?>">
-                                        <input type="number" name="options[<?php echo esc_attr($option_index); ?>][choices][<?php echo $choice_index; ?>][price]" class="form-input w-24" placeholder="Price" value="<?php echo esc_attr($choice['price'] ?? ''); ?>" step="0.01">
+                                        <input type="text" name="options[<?php echo esc_attr($option_index); ?>][choices][<?php echo $choice_index; ?>][label]" class="regular-text flex-1" placeholder="Choice Label" value="<?php echo esc_attr($choice['label'] ?? $choice); ?>">
+                                        <input type="number" name="options[<?php echo esc_attr($option_index); ?>][choices][<?php echo $choice_index; ?>][price]" class="regular-text w-24" placeholder="Price" value="<?php echo esc_attr($choice['price'] ?? ''); ?>" step="0.01">
                                         <button type="button" class="btn-icon remove-choice-btn">
                                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><path d="m19 6-1 14H6L5 6"/></svg>
                                         </button>


### PR DESCRIPTION
This commit redesigns the service edit page to align with the main dashboard's styling. It replaces the previous tabbed layout with a two-column design, creating a more modern and consistent user experience.

Key changes include:
- A new "Actions" card in the sidebar for primary actions like saving and changing the service status.
- Removal of "Save Draft", "Cancel", and "Duplicate" buttons, replaced by a "Back" button in the header for cleaner navigation.
- Improved styling for the "Visuals" and "Service Options" cards to enhance clarity and readability.
- Refactored HTML, CSS, and JavaScript to support the new layout and remove legacy code.