### PR TITLE
feat: Redesign service edit page and add new features

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -1189,3 +1189,77 @@ a.quick-action:hover {
     padding: 1.5rem;
     border-top: 1px solid hsl(var(--border));
 }
+
+.mobooking-option-content .form-label {
+    display: block;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: hsl(var(--foreground));
+    margin-bottom: 0.5rem;
+}
+
+.mobooking-option-content .form-input,
+.mobooking-option-content .form-textarea {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-size: 0.875rem;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.mobooking-option-content .form-input:focus,
+.mobooking-option-content .form-textarea:focus {
+    outline: none;
+    border-color: hsl(var(--ring));
+    box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+}
+
+.mobooking-option-content .grid {
+    display: grid;
+}
+
+.mobooking-option-content .grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.mobooking-option-content .md\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.mobooking-option-content .gap-4 {
+    gap: 1rem;
+}
+
+.mobooking-option-content .md\:col-span-2 {
+    grid-column: span 2 / span 2;
+}
+
+.mobooking-option-content .space-y-4 > * + * {
+    margin-top: 1rem;
+}
+
+.mobooking-icon-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+    gap: 1rem;
+    padding: 1rem;
+}
+
+.mobooking-icon-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background-color 0.2s, border-color 0.2s;
+}
+
+.mobooking-icon-wrapper:hover {
+    background-color: hsl(var(--accent));
+    border-color: hsl(var(--ring));
+}

--- a/assets/js/dashboard-service-edit.js
+++ b/assets/js/dashboard-service-edit.js
@@ -72,9 +72,9 @@ jQuery(function ($) {
 
       // Toggle option
       $container.on("click", ".toggle-option", function () {
-        const $optionElement = $(this).closest(".option-item");
+        const $optionElement = $(this).closest(".mobooking-option-item");
         $optionElement.toggleClass("expanded");
-        $optionElement.find(".option-content").slideToggle(200);
+        $optionElement.find(".mobooking-option-content").slideToggle(200);
       });
 
       // Delete option
@@ -85,10 +85,9 @@ jQuery(function ($) {
               "Are you sure you want to delete this option?"
           )
         ) {
-          $(this).closest(".option-item").remove();
-          self.updateOptionsBadge();
+          $(this).closest(".mobooking-option-item").remove();
 
-          if ($(".option-item").length === 0) {
+          if ($(".mobooking-option-item").length === 0) {
             self.showEmptyState();
           }
         }
@@ -97,7 +96,7 @@ jQuery(function ($) {
       // Update option name in header
       $container.on("input", ".option-name-input", function () {
         const $input = $(this);
-        const nameDisplay = $input.closest(".option-item").find(".option-name");
+        const nameDisplay = $input.closest(".mobooking-option-item").find(".mobooking-option-name");
         nameDisplay.text($input.val() || "New Option");
       });
 
@@ -461,8 +460,50 @@ jQuery(function ($) {
     },
 
     openIconSelector: function () {
-      // Implementation for icon selector would go here
-      console.log("Icon selector functionality not yet implemented");
+        const self = this;
+        const icons = {
+            copy: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-copy"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>',
+            plus: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-plus"><path d="M5 12h14"/><path d="M12 5v14"/></svg>',
+            trash: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trash-2"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg>',
+            star: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>',
+            tools: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M21.69 18.56l-1.41-1.41c-.54-.54-1.29-.8-2.09-.69l-1.44.21c-.33.05-.6.31-.6.64v1.5c0 .28.22.5.5.5h.5c2.21 0 4-1.79 4-4v-.5c0-.33-.27-.59-.6-.54l-1.44.21c-.8.11-1.55.38-2.09.92L16.56 17H7.44l-1.41-1.41c-.54-.54-1.29-.8-2.09-.69l-1.44.21c-.33.05-.6.31-.6.64v1.5c0 .28.22.5.5.5h.5c2.21 0 4-1.79 4-4v-.5c0-.33-.27-.59-.6-.54l-1.44.21c-.8.11-1.55.38-2.09.92L1.94 17H1v-2.44l1.41-1.41c.54-.54.8-.1.69-2.09l-.21-1.44c-.05-.33.21-.6.54-.6h1.5c.28 0 .5.22.5.5v.5c0 2.21 1.79 4 4 4h.5c.33 0 .59-.27.54-.6l-.21-1.44c-.11-.8.15-1.55.92-2.09L12 7.44V1H9.56L8.14 2.41c-.54.54-.8 1.29-.69 2.09l.21 1.44c.05.33.31.6.64.6h1.5c.28 0 .5-.22.5-.5v-.5c0-2.21-1.79-4-4-4H1.5c-.33 0-.59.27-.54.6l.21 1.44c.11.8-.15 1.55-.92 2.09L-.44 7H-3v2.44l1.41 1.41c.54.54.8 1.29.69 2.09l-.21 1.44c-.05.33.21-.6.54-.6h1.5c.28 0 .5.22.5.5v.5c0 2.21 1.79 4 4 4h8c2.21 0 4-1.79 4-4v-.5c0-.28-.22-.5-.5-.5h-1.5c-.33 0-.6-.27-.6-.6l.21-1.44c.11-.8-.15-1.55-.92-2.09L14.56 10H12V7.44l1.41-1.41c.54-.54 1.29-.8 2.09-.69l1.44.21c.33.05.6.31.6.64v1.5c0 .28-.22.5-.5.5h-.5c-2.21 0-4 1.79-4 4v.5c0 .33.27.59.6.54l1.44-.21c.8-.11 1.55-.38 2.09-.92l1.41-1.41H21.69zM12 14c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z"/></svg>',
+        };
+
+        const iconGrid = document.createElement('div');
+        iconGrid.className = 'mobooking-icon-grid';
+
+        for (const [name, svg] of Object.entries(icons)) {
+            const iconWrapper = document.createElement('div');
+            iconWrapper.className = 'mobooking-icon-wrapper';
+            iconWrapper.dataset.iconName = name;
+            iconWrapper.innerHTML = svg;
+            iconGrid.appendChild(iconWrapper);
+        }
+
+        const dialog = new MoBookingDialog({
+            title: 'Choose an Icon',
+            content: iconGrid,
+            buttons: [
+                {
+                    label: 'Close',
+                    class: 'secondary',
+                    onClick: (dialog) => dialog.close(),
+                },
+            ],
+        });
+
+        dialog.show();
+
+        dialog.findElement('.mobooking-icon-grid').addEventListener('click', function (e) {
+            const wrapper = e.target.closest('.mobooking-icon-wrapper');
+            if (wrapper) {
+                const iconName = wrapper.dataset.iconName;
+                const iconSvg = icons[iconName];
+                $('#current-icon').html(iconSvg);
+                $('#service-icon').val(iconSvg);
+                dialog.close();
+            }
+        });
     },
 
     handleImageUpload: function (file) {

--- a/dashboard/page-service-edit.php
+++ b/dashboard/page-service-edit.php
@@ -188,12 +188,6 @@ if ( $edit_mode && $service_id > 0 ) {
 				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
 				<?php esc_html_e( 'Back', 'mobooking' ); ?>
 			</a>
-			<?php if ( $edit_mode ) : ?>
-				<button type="button" id="delete-service-btn" class="btn btn-destructive btn-sm">
-					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><path d="m19 6-1 14H6L5 6"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
-					<?php esc_html_e( 'Delete', 'mobooking' ); ?>
-				</button>
-			<?php endif; ?>
 		</div>
 	</div>
 
@@ -370,6 +364,13 @@ if ( $edit_mode && $service_id > 0 ) {
 								<input type="hidden" name="status" value="<?php echo esc_attr( $service_status ); ?>">
 							</div>
 						</div>
+						<?php if ( $edit_mode ) : ?>
+						<hr class="my-4">
+						<button type="button" id="delete-service-btn" class="btn btn-destructive btn-sm w-full">
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><path d="m19 6-1 14H6L5 6"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+							<?php esc_html_e( 'Delete Service', 'mobooking' ); ?>
+						</button>
+						<?php endif; ?>
 					</div>
 				</div>
 				<!-- Visual Settings Card -->

--- a/functions/routing.php
+++ b/functions/routing.php
@@ -108,7 +108,6 @@ function mobooking_enqueue_dashboard_scripts($current_page_slug = '') {
     // Specific to Service Edit page
     if ($current_page_slug === 'service-edit') {
         error_log('[MoBooking Debug] Correctly identified service-edit page. Enqueueing scripts.');
-        wp_enqueue_style('mobooking-dashboard-service-edit', MOBOOKING_THEME_URI . 'assets/css/dashboard-service-edit.css', array(), MOBOOKING_VERSION);
         wp_enqueue_script('mobooking-service-edit', MOBOOKING_THEME_URI . 'assets/js/dashboard-service-edit.js', array('jquery'), MOBOOKING_VERSION, true);
 
         $service_id = isset($_GET['service_id']) ? intval($_GET['service_id']) : 0;


### PR DESCRIPTION
This commit completely redesigns the service edit page to align with the main dashboard's styling and introduces several new features and bug fixes based on user feedback.

The key changes include:
- A new "Actions" card in the sidebar for primary actions like saving, changing the service status, and deleting the service.
- Removal of "Save Draft", "Cancel", and "Duplicate" buttons, replaced by a "Back" button in the header for cleaner navigation.
- Improved styling for the "Visuals" and "Service Options" cards to enhance clarity and readability.
- Refactored HTML, CSS, and JavaScript to support the new layout and remove legacy code.
- Implemented a new "Choose Icon" functionality using a dialog modal.
- Fixed several bugs, including a missing stylesheet error, JavaScript errors related to the old tabbed interface, and an issue where the service option panels would not open.