### PR TITLE
feat: Redesign service edit page, add features, and fix bugs

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -1263,3 +1263,37 @@ a.quick-action:hover {
     background-color: hsl(var(--accent));
     border-color: hsl(var(--ring));
 }
+
+/* Switch button styles */
+.switch {
+    position: relative;
+    display: inline-flex;
+    height: 1.5rem;
+    width: 2.75rem;
+    cursor: pointer;
+    border-radius: 9999px;
+    border: none;
+    background-color: hsl(var(--input));
+    transition: background-color 0.2s;
+}
+
+.switch.switch-checked {
+    background-color: hsl(var(--primary));
+}
+
+.switch-thumb {
+    display: block;
+    height: 1.25rem;
+    width: 1.25rem;
+    border-radius: 50%;
+    background-color: hsl(var(--background));
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: transform 0.2s;
+    transform: translateX(0.125rem);
+    position: absolute;
+    top: 0.125rem;
+}
+
+.switch.switch-checked .switch-thumb {
+    transform: translateX(1.375rem);
+}

--- a/assets/js/dashboard-service-edit.js
+++ b/assets/js/dashboard-service-edit.js
@@ -104,10 +104,10 @@ jQuery(function ($) {
       $container.on("change", ".option-type-radio", function () {
         const $radio = $(this);
         const type = $radio.val();
-        const $optionItem = $radio.closest(".option-item");
+        const $optionItem = $radio.closest(".mobooking-option-item");
 
         // Update badge
-        const badge = $optionItem.find(".option-badges .badge-outline");
+        const badge = $optionItem.find(".mobooking-option-badges .badge-outline");
         const typeLabel = $radio
           .closest(".option-type-card")
           .find(".option-type-title")
@@ -121,13 +121,11 @@ jQuery(function ($) {
         const $choicesList = $optionItem.find(".choices-list");
         const choiceTypes = ["select", "radio", "checkbox"];
 
-        // Always clear choices when the type changes, to avoid mismatched inputs.
-        $choicesList.empty();
-
         if (choiceTypes.includes(type)) {
-          $choicesContainer.slideDown(200);
+            $choicesContainer.slideDown(200);
         } else {
-          $choicesContainer.slideUp(200);
+            $choicesContainer.slideUp(200);
+            $choicesList.empty(); // Clear choices only when hiding
         }
 
         // Handle SQM/Kilometers specific UI
@@ -507,8 +505,31 @@ jQuery(function ($) {
     },
 
     handleImageUpload: function (file) {
-      // Implementation for image upload would go here
-      console.log("Image upload functionality not yet implemented");
+        const self = this;
+        const formData = new FormData();
+        formData.append('service_image', file);
+        formData.append('action', 'mobooking_upload_service_image');
+        formData.append('nonce', mobooking_service_edit_params.nonce);
+
+        $.ajax({
+            url: mobooking_service_edit_params.ajax_url,
+            type: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false,
+            success: function (response) {
+                if (response.success) {
+                    const $preview = $('#image-preview');
+                    $preview.html(`<img src="${response.data.image_url}" alt="Service Image"><button type="button" class="remove-image-btn"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><path d="m19 6-1 14H6L5 6"/></svg></button>`);
+                    $('#service-image-url').val(response.data.image_url);
+                } else {
+                    alert(response.data.message);
+                }
+            },
+            error: function () {
+                alert('AJAX error occurred while uploading image.');
+            },
+        });
     },
 
     removeImage: function () {


### PR DESCRIPTION
This commit completely redesigns the service edit page to align with the main dashboard's styling and introduces several new features and bug fixes based on user feedback.

The key changes include:
- A new "Actions" card in the sidebar for primary actions like saving, changing the service status, and deleting the service.
- Removal of "Save Draft", "Cancel", and "Duplicate" buttons, replaced by a "Back" button in the header for cleaner navigation.
- Improved styling for the "Visuals" and "Service Options" cards to enhance clarity and readability.
- Refactored HTML, CSS, and JavaScript to support the new layout and remove legacy code.
- Implemented a new "Choose Icon" functionality using a dialog modal.
- Fixed several bugs, including a missing stylesheet error, JavaScript errors related to the old tabbed interface, and an issue where the service option panels would not open.
- Fixed image and icon upload functionality to ensure they save and display correctly.
- Corrected CSS for switch buttons to ensure consistent display.
- Fixed JavaScript logic for service options to correctly show and hide choices.