### PR TITLE
feat: Implement icon selector and improve service editing UX

### DIFF
--- a/classes/Services.php
+++ b/classes/Services.php
@@ -1151,6 +1151,13 @@ public function handle_get_public_services_ajax() {
                 return;
             }
 
+        $duration_from_post = isset($_POST['duration']) ? intval($_POST['duration']) : 0;
+        if ($duration_from_post < 30) {
+            if (ob_get_length()) ob_clean();
+            wp_send_json_error(['message' => __('Duration must be at least 30 minutes.', 'mobooking')], 400);
+            return;
+        }
+
         // Prepare data, converting empty optional strings to null
         $icon_from_post = isset($_POST['icon']) ? trim($_POST['icon']) : '';
         $image_url_from_post = isset($_POST['image_url']) ? trim($_POST['image_url']) : '';

--- a/dashboard/page-service-edit.php
+++ b/dashboard/page-service-edit.php
@@ -283,7 +283,7 @@ if ( $edit_mode && $service_id > 0 ) {
 									class="regular-text"
 									placeholder="<?php esc_attr_e( 'e.g., 120', 'mobooking' ); ?>"
 									value="<?php echo esc_attr( $service_duration ); ?>"
-									min="15"
+									min="30"
 									step="15"
 									required
 								>
@@ -438,3 +438,41 @@ if ( $edit_mode && ! empty( $service_options_data ) ) {
 	// This script is no longer needed as the tabbed interface has been removed.
 }
 ?>
+<!-- Icon Selector Modal -->
+<div id="mobooking-icon-modal" class="mobooking-modal" style="display: none;">
+	<div class="mobooking-modal-backdrop"></div>
+	<div class="mobooking-modal-content">
+		<div class="mobooking-modal-header">
+			<h3 class="mobooking-modal-title"><?php esc_html_e( 'Choose an Icon', 'mobooking' ); ?></h3>
+			<button type="button" class="mobooking-modal-close">
+				<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+			</button>
+		</div>
+		<div class="mobooking-modal-body">
+			<!-- Preset Icons Section -->
+			<div class="preset-icons-section">
+				<h4 class="section-title"><?php esc_html_e( 'Preset Icons', 'mobooking' ); ?></h4>
+				<div id="preset-icons-grid" class="mobooking-icon-grid">
+					<!-- Icons will be loaded here by JavaScript -->
+					<div class="icon-grid-loading">
+						<p><?php esc_html_e( 'Loading icons...', 'mobooking' ); ?></p>
+					</div>
+				</div>
+			</div>
+			<hr class="my-4">
+			<!-- Custom Icon Section -->
+			<div class="custom-icon-section">
+				<h4 class="section-title"><?php esc_html_e( 'Upload Custom Icon', 'mobooking' ); ?></h4>
+				<p class="section-description"><?php esc_html_e( 'Upload your own SVG icon. For best results, use a simple, single-color SVG.', 'mobooking' ); ?></p>
+				<input type="file" id="custom-icon-upload" accept=".svg" class="mt-2">
+				<div id="custom-icon-upload-feedback" class="text-sm mt-2"></div>
+			</div>
+		</div>
+		<div class="mobooking-modal-footer">
+			<button type="button" id="remove-icon-btn" class="btn btn-destructive"><?php esc_html_e( 'Remove Icon', 'mobooking' ); ?></button>
+			<div class="flex-grow"></div>
+			<button type="button" class="btn btn-secondary mobooking-modal-close"><?php esc_html_e( 'Cancel', 'mobooking' ); ?></button>
+			<button type="button" id="set-icon-btn" class="btn btn-primary" disabled><?php esc_html_e( 'Set Icon', 'mobooking' ); ?></button>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
This commit introduces a full-featured icon selector for services and makes several other UX improvements to the service editing page.

- **Implement Icon Selector:** A new modal dialog allows users to choose a service icon.
  - Users can select from a list of preset icons fetched via AJAX.
  - Users can upload their own custom SVG icons.
  - The chosen icon can be set or removed.
  - The backend handles fetching presets, and uploading/deleting custom icons.

- **Enforce Minimum Duration:** The service duration is now validated to be at least 30 minutes. This is enforced with a `min` attribute on the frontend and with a check on the backend.