### PR TITLE
fix: Resolve icon display and status switch bugs

### DIFF
--- a/assets/js/dashboard-service-edit.js
+++ b/assets/js/dashboard-service-edit.js
@@ -169,6 +169,31 @@ jQuery(function ($) {
         self.removeImage();
       });
 
+      // General switch handler for the entire form
+      $(document).on("click", ".service-form .switch", function() {
+          const $switch = $(this);
+          const $hiddenInput = $switch.siblings("input[type=hidden]");
+          const isChecked = $switch.hasClass("switch-checked");
+          const switchType = $switch.data("switch");
+
+          $switch.toggleClass("switch-checked");
+
+          if (switchType === 'status') {
+              const newValue = isChecked ? 'inactive' : 'active';
+              $hiddenInput.val(newValue);
+              $switch.parent().find(".text-sm").text(isChecked ? 'Inactive' : 'Active');
+          } else { // Handle other switches like 'is_required'
+              const newValue = isChecked ? '0' : '1';
+              $hiddenInput.val(newValue);
+               if (switchType === "required") {
+                  const $label = $switch.parent().find(".text-sm");
+                  if ($label.length) {
+                    $label.text(newValue === "1" ? "Required option" : "Optional");
+                  }
+                }
+          }
+      });
+
       // --- Delegated Option Events ---
 
       // Toggle option
@@ -338,30 +363,6 @@ jQuery(function ($) {
         // Update hidden input
         $optionItem.find(".price-impact-type-input").val($radio.val());
       });
-
-      // Switch toggles
-      $container.on("click", ".switch", function () {
-        const $switch = $(this);
-        const isChecked = $switch.hasClass("switch-checked");
-        const newValue = isChecked ? "0" : "1";
-
-        $switch.toggleClass("switch-checked");
-        $switch.siblings("input[type=hidden]").val(newValue);
-
-        if ($switch.data("switch") === "required") {
-          const $label = $switch.parent().find(".text-sm");
-          if ($label.length) {
-            $label.text(newValue === "1" ? "Required option" : "Optional");
-          }
-        }
-
-        if ($switch.data("switch") === "status") {
-          const $label = $switch.parent().find(".text-sm");
-          if ($label.length) {
-            $label.text(newValue === "1" ? "Active" : "Inactive");
-          }
-        }
-      });
     },
 
     initSwitches: function () {
@@ -369,26 +370,28 @@ jQuery(function ($) {
         const $switchEl = $(this);
         const $hiddenInput = $switchEl.siblings("input[type=hidden]");
         const currentValue = $hiddenInput.val();
-        const isChecked = currentValue === "1";
 
-        if (isChecked) {
-          $switchEl.addClass("switch-checked");
-        } else {
-          $switchEl.removeClass("switch-checked");
-        }
+        if ($switchEl.data("switch") === 'status') {
+            if (currentValue === 'active') {
+                $switchEl.addClass("switch-checked");
+            } else {
+                $switchEl.removeClass("switch-checked");
+            }
+            $switchEl.parent().find(".text-sm").text(currentValue === 'active' ? 'Active' : 'Inactive');
+        } else { // Handle other switches like 'is_required'
+            const isChecked = currentValue === "1";
+            if (isChecked) {
+              $switchEl.addClass("switch-checked");
+            } else {
+              $switchEl.removeClass("switch-checked");
+            }
 
-        if ($switchEl.data("switch") === "required") {
-          const $label = $switchEl.parent().find(".text-sm");
-          if ($label.length) {
-            $label.text(isChecked ? "Required option" : "Optional");
-          }
-        }
-
-        if ($switchEl.data("switch") === "status") {
-          const $label = $switchEl.parent().find(".text-sm");
-          if ($label.length) {
-            $label.text(isChecked ? "Active" : "Inactive");
-          }
+            if ($switchEl.data("switch") === "required") {
+              const $label = $switchEl.parent().find(".text-sm");
+              if ($label.length) {
+                $label.text(isChecked ? "Required option" : "Optional");
+              }
+            }
         }
       });
     },

--- a/classes/Services.php
+++ b/classes/Services.php
@@ -22,8 +22,8 @@ class Services {
         global $wpdb;
         $this->wpdb = $wpdb;
         $this->service_options_manager = new ServiceOptions();
-        // Define the path to the preset icons directory. MOBOOKING_PLUGIN_DIR should be defined in the main plugin file.
-        self::$preset_icons_path = defined('MOBOOKING_PLUGIN_DIR') ? MOBOOKING_PLUGIN_DIR . 'assets/svg-icons/presets/' : plugin_dir_path(__FILE__) . '../../assets/svg-icons/presets/';
+        // Define the path to the preset icons directory using the theme directory constant.
+        self::$preset_icons_path = MOBOOKING_THEME_DIR . 'assets/svg-icons/presets/';
     }
 
     public static function get_preset_icon_svg(string $filename): ?string {

--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
  */
 
 if ( ! defined( 'MOBOOKING_VERSION' ) ) {
-    define( 'MOBOOKING_VERSION', '0.1.6' );
+    define( 'MOBOOKING_VERSION', '0.1.7' );
 }
 if ( ! defined( 'MOBOOKING_DB_VERSION' ) ) {
     define( 'MOBOOKING_DB_VERSION', '2.1' );


### PR DESCRIPTION
This commit fixes two outstanding issues from user feedback:
1.  Preset icons were not displaying in the icon selector dialog because of an incorrect server-side path to the icons directory.
2.  The "Status" toggle switch on the service edit page was unresponsive.

- **Fix Preset Icon Path:** The path to the preset icons directory in `classes/Services.php` has been corrected to use the `MOBOOKING_THEME_DIR` constant. This ensures the backend can reliably find and serve the SVG files for the dialog.

- **Fix Status Switch Logic:** The JavaScript event handler for toggle switches in `assets/js/dashboard-service-edit.js` has been refactored. It is now delegated from the document to correctly capture clicks on the status switch. The handler logic has also been corrected to use the appropriate 'active'/'inactive' string values.

- **Update Asset Version:** The plugin version has been bumped to `0.1.7` to ensure all users receive the updated JavaScript file.