### PR TITLE
Fix: Allow saving empty service area selection

### DIFF
--- a/classes/Areas.php
+++ b/classes/Areas.php
@@ -161,8 +161,8 @@ public function get_areas_for_city($country_code, $city_code) {
             return new \WP_Error('invalid_user', __('Invalid user.', 'mobooking'));
         }
 
-        if (empty($areas_data) || !is_array($areas_data)) {
-            return new \WP_Error('invalid_data', __('Invalid areas data.', 'mobooking'));
+    if (!is_array($areas_data)) {
+        return new \WP_Error('invalid_data', __('Invalid areas data. Must be an array.', 'mobooking'));
         }
 
         $table_name = Database::get_table_name('areas');


### PR DESCRIPTION
This commit resolves a `400 Bad Request` error that occurred when saving a city with no service areas selected.

The root cause was a validation check in the `add_bulk_areas` function that incorrectly treated an empty `areas_data` array as an error. This prevented users from being able to deselect all areas for a city and save that change.

The validation has been adjusted to only check if the input is an array, allowing an empty array to be processed successfully. This ensures the correct behavior of deleting all areas for a city when an empty set is saved.

This commit builds upon the previous fixes that aligned the `Areas` class with the database schema and replaced the legacy modal with the system dialog.