### PR TITLE
Fix: Correct Service Coverage display and standardize filter design

### DIFF
--- a/dashboard/page-areas.php
+++ b/dashboard/page-areas.php
@@ -63,27 +63,35 @@ $current_user_id = get_current_user_id();
             </div>
 
             <!-- Search and Filter Controls -->
-            <div class="mobooking-table-controls">
-                <div class="mobooking-search-filter-row">
-                    <div class="mobooking-search-group">
-                        <div class="mobooking-search-input-wrapper">
-                            <input type="text" id="coverage-search" class="mobooking-search-input" placeholder="<?php esc_attr_e('Search cities or areas...', 'mobooking'); ?>">
+            <div class="mobooking-filters-wrapper" style="margin-bottom: 1.5rem;">
+                <form id="mobooking-areas-filter-form" class="mobooking-filters-form">
+                    <div class="mobooking-filters-main">
+                        <div class="mobooking-filter-item mobooking-filter-item-search">
+                            <label for="coverage-search"><?php esc_html_e('Search', 'mobooking'); ?></label>
+                            <input type="search" id="coverage-search" class="regular-text" placeholder="<?php esc_attr_e('Search cities...', 'mobooking'); ?>">
+                        </div>
+                        <div class="mobooking-filter-item">
+                            <label for="city-filter"><?php esc_html_e('City', 'mobooking'); ?></label>
+                            <select id="city-filter" class="mobooking-filter-select">
+                                <option value=""><?php esc_html_e('All Cities', 'mobooking'); ?></option>
+                            </select>
+                        </div>
+                        <div class="mobooking-filter-item">
+                            <label for="status-filter"><?php esc_html_e('Status', 'mobooking'); ?></label>
+                            <select id="status-filter" class="mobooking-filter-select">
+                                <option value=""><?php esc_html_e('All Statuses', 'mobooking'); ?></option>
+                                <option value="active"><?php esc_html_e('Active', 'mobooking'); ?></option>
+                                <option value="inactive"><?php esc_html_e('Inactive', 'mobooking'); ?></option>
+                            </select>
+                        </div>
+                        <div class="mobooking-filter-actions">
+                            <button type="button" id="clear-coverage-filters-btn" class="btn btn-outline">
+                                <?php echo mobooking_get_feather_icon('x'); ?>
+                                <span class="btn-text"><?php esc_html_e('Clear', 'mobooking'); ?></span>
+                            </button>
                         </div>
                     </div>
-                    <div class="mobooking-filter-group">
-                        <select id="city-filter" class="mobooking-form-select mobooking-form-select-sm">
-                            <option value=""><?php esc_html_e('All Cities', 'mobooking'); ?></option>
-                        </select>
-                        <select id="status-filter" class="mobooking-form-select mobooking-form-select-sm">
-                            <option value=""><?php esc_html_e('All Statuses', 'mobooking'); ?></option>
-                            <option value="active"><?php esc_html_e('Active', 'mobooking'); ?></option>
-                            <option value="inactive"><?php esc_html_e('Inactive', 'mobooking'); ?></option>
-                        </select>
-                        <button type="button" id="clear-coverage-filters-btn" class="btn btn-secondary btn-sm">
-                            <?php esc_html_e('Clear', 'mobooking'); ?>
-                        </button>
-                    </div>
-                </div>
+                </form>
             </div>
 
             <!-- Service Coverage Display -->


### PR DESCRIPTION
This commit addresses two follow-up issues on the Service Areas page:

1.  **Fixes Service Coverage Display:** The "Your Service Coverage" section was not displaying saved cities. This was because the `get_service_coverage_grouped` function was querying for a non-existent `area_type` of 'city'. The function has been rewritten to correctly derive the city summary by fetching all saved ZIP codes for the user and then mapping them back to their respective cities using the `service-areas-data.json` file. This ensures the summary is now displayed correctly.

2.  **Standardizes Filter Design:** The filter controls on the Service Areas page had an inconsistent design compared to the rest of the dashboard. The HTML structure has been updated to use the standard filter classes (`mobooking-filters-wrapper`, `mobooking-filter-item`, etc.) and elements (`<label>`) found on other pages like the Bookings page, ensuring a consistent user interface.