### PR TITLE
Feat: Enhance service area management with grouping, status, and search

### DIFF
--- a/assets/css/dialog.css
+++ b/assets/css/dialog.css
@@ -154,6 +154,29 @@
   animation: slideOut 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
+/* Styles for the search input in the dialog */
+.dialog-search-wrapper {
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--dialog-border);
+  margin-bottom: 1rem;
+}
+
+.mobooking-dialog-search-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--dialog-border);
+  border-radius: var(--dialog-radius);
+  font-size: 1rem;
+  background-color: var(--dialog-secondary);
+  color: var(--dialog-foreground);
+}
+
+.mobooking-dialog-search-input:focus {
+  outline: 2px solid var(--dialog-primary);
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
 /* Styles for the areas selection grid inside the dialog */
 .modal-areas-grid {
   display: grid;

--- a/assets/js/enhanced-areas.js
+++ b/assets/js/enhanced-areas.js
@@ -142,6 +142,9 @@
      */
     function openModal() {
         const dialogContent = `
+            <div class="dialog-search-wrapper">
+                <input type="search" id="dialog-area-search" placeholder="Search areas..." class="mobooking-dialog-search-input">
+            </div>
             <div class="areas-selection-controls">
                 <button type="button" id="dialog-select-all" class="btn btn-link">${i18n.select_all || 'Select All'}</button>
                 <button type="button" id="dialog-deselect-all" class="btn btn-link">${i18n.deselect_all || 'Deselect All'}</button>
@@ -176,6 +179,21 @@
                 // Bind expand/collapse toggle
                 $(dialogEl).on('click', '.area-zip-toggle', function() {
                     $(this).closest('.modal-area-item').toggleClass('is-expanded');
+                });
+
+                // Bind search input
+                $(dialogEl).on('input', '#dialog-area-search', function() {
+                    const searchTerm = $(this).val().toLowerCase();
+                    const $items = $(dialogEl).find('.modal-area-item');
+
+                    $items.each(function() {
+                        const areaName = $(this).find('.area-name').text().toLowerCase();
+                        if (areaName.includes(searchTerm)) {
+                            $(this).show();
+                        } else {
+                            $(this).hide();
+                        }
+                    });
                 });
 
                 // Fetch areas
@@ -258,13 +276,30 @@
             return;
         }
 
-        let html = "";
-        placeNames.sort().forEach(function (placeName) {
+        const savedPlaceNames = [];
+        const unsavedPlaceNames = [];
+
+        placeNames.forEach(function(placeName) {
             const locations = areas[placeName];
             const locationZips = locations.map(loc => loc.zipcode);
             const allZipsSaved = locationZips.every(zip => savedAreas.includes(zip));
+            if (allZipsSaved) {
+                savedPlaceNames.push(placeName);
+            } else {
+                unsavedPlaceNames.push(placeName);
+            }
+        });
+
+        savedPlaceNames.sort();
+        unsavedPlaceNames.sort();
+
+        const sortedPlaceNames = [...savedPlaceNames, ...unsavedPlaceNames];
+
+        let html = "";
+        sortedPlaceNames.forEach(function (placeName) {
+            const locations = areas[placeName];
+            const allZipsSaved = savedPlaceNames.includes(placeName); // We already know this, just reuse for the checkbox
             const areaData = escapeHtml(JSON.stringify(locations));
-            const zipCodesDisplay = locations.map(l => l.zipcode).join(', ');
 
             html += `
                 <div class="modal-area-item">


### PR DESCRIPTION
This commit introduces several major enhancements to the service area management feature:

- **Grouped Area Selection:** In the dialog, areas are now grouped by 'place' name. A new expand/collapse toggle allows users to view the associated zip codes for each place.
- **Active/Inactive Status:** Users can now toggle the status of all areas within a city (state) between 'active' and 'inactive' from the 'Your Service Coverage' grid.
- **Search and Sorting:** The selection dialog now includes a search bar to filter areas by name. Saved areas are now sorted to the top of the list for better visibility.
- **Database Migration:** The database schema for the 'areas' table has been updated to include 'status' and 'area_data' columns. The database version has been incremented to ensure this migration runs on existing installations, fixing the 'Unknown column' error.
- **Bug Fixes:**
  - Corrected an issue that prevented saved service areas from being displayed in the 'Your Service Coverage' list.
  - Fixed a JavaScript error that was preventing area selections from being saved to the database.
- **UI/Styling Improvements:**
  - The area selection dialog has been restyled for a cleaner UI.
  - The grid of areas in the dialog is now scrollable when its content exceeds a maximum height.