### PR TITLE
feat: Enhance booking form UI and fix settings bugs

### DIFF
--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -52,6 +52,7 @@ class Settings {
                 'bf_enable_recaptcha'         => '0',
                 'bf_enable_ssl_required'      => '1',
                 'bf_debug_mode'               => '0',
+                'bf_service_card_display'     => 'image',
 
                 // Business Settings
                 'biz_name'                            => '',

--- a/functions/theme-setup.php
+++ b/functions/theme-setup.php
@@ -341,11 +341,13 @@ if ( is_page_template('templates/booking-form-public.php') || $page_type_for_scr
             'nonce' => wp_create_nonce('mobooking_dashboard_nonce')
         ]);
 
-        if ( $current_page_slug === 'settings' ) {
+        if ( $current_page_slug === 'settings' || $current_page_slug === 'booking-form' ) {
             // Enqueue styles for color picker
             wp_enqueue_style( 'wp-color-picker' );
             // Enqueue the settings page specific CSS
             wp_enqueue_style( 'mobooking-dashboard-settings', MOBOOKING_THEME_URI . 'assets/css/dashboard-settings.css', array('mobooking-dashboard-main'), MOBOOKING_VERSION );
+
+            wp_enqueue_script( 'mobooking-dashboard-booking-form-settings', MOBOOKING_THEME_URI . 'assets/js/dashboard-booking-form-settings.js', array('jquery', 'wp-color-picker'), MOBOOKING_VERSION, true );
 
             // Enqueue SortableJS for the email builder
             wp_enqueue_script( 'sortable-js', 'https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js', array(), '1.15.0', true );


### PR DESCRIPTION
This commit introduces several UI/UX improvements to the booking form and its dashboard settings, and fixes two bugs related to settings not saving and the color picker not working.

The key changes include:

- A new dashboard setting to allow users to choose between displaying a service's image or its icon on the booking form.
- The live preview in the dashboard settings has been enhanced to show a wider variety of form elements for a more accurate representation.
- The calendar and time slot picker on the public booking form have been redesigned with a cleaner, more modern layout.
- The styling for the new 'Service Card Display' setting in the dashboard has been improved to be more visually appealing and user-friendly.
- The booking form's CSS has been further refined to ensure consistency with the dashboard's design system.
- The 'bf_service_card_display' setting is now correctly saved by adding it to the default settings array.
- The `wp-color-picker` script and styles are now correctly enqueued on the booking form settings page, fixing the color picker functionality.