### PR TITLE
Fix booking form logic and data handling

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -197,6 +197,20 @@ jQuery(document).ready(function ($) {
         els.timeSlots.empty();
         collapseTimeSlots(true);
         break;
+      case 7: // Reset customer details
+        state.customer = { name: "", email: "", phone: "", address: "", instructions: "" };
+        state.propertyAccess = { method: "home", details: "" };
+        els.nameInput.val('');
+        els.emailInput.val('');
+        els.phoneInput.val('');
+        els.addressInput.val('');
+        $("#mobooking-special-instructions").val('');
+        $('input[name="property_access"][value="home"]').prop('checked', true).trigger('change');
+        $("#mobooking-access-instructions").val('');
+        break;
+      case 8: // Reset confirmation summary
+        $("#mobooking-confirmation-details").html('');
+        break;
     }
   }
 
@@ -890,7 +904,7 @@ jQuery(document).ready(function ($) {
     const base = state.pricing.base || 0;
     if (!impact) return 0;
     if (type === "percentage") return (base * impact) / 100;
-    if (type === "multiply") return base * impact;
+    if (type === "multiply") return base * (impact > 0 ? impact - 1 : 0);
     return impact * (quantity || 1);
   }
 


### PR DESCRIPTION
This commit addresses three issues in the public booking form:
1.  Corrects the price calculation for service options with a 'multiply' impact type. The previous logic incorrectly added a multiplied value to the base price instead of adjusting the total.
2.  Implements a complete data reset mechanism. When a user navigates backward, the data for the step they are leaving is now cleared. This was already partially implemented, and this change adds the missing logic for the customer details and confirmation steps.
3.  Verifies that the summary card visibility logic correctly hides the card on steps 1, 2, 7, 8, and 9, as per requirements. No change was needed as the existing code already handled this.