### PR TITLE
refactor: Unify option styles and add quantity stepper

### DIFF
--- a/assets/css/booking-form-modern.css
+++ b/assets/css/booking-form-modern.css
@@ -311,8 +311,8 @@
   margin-bottom: 0;
 }
 
-/* Custom Checkbox Styles */
-.mobooking-checkbox-option {
+/* Custom Selectable Options (Checkbox & Radio) */
+.mobooking-selectable-option {
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -324,32 +324,40 @@
   margin-bottom: 0.5rem;
 }
 
-.mobooking-checkbox-option:hover {
+.mobooking-selectable-option:hover {
   background-color: hsl(var(--accent));
 }
 
-.mobooking-checkbox-option input[type="checkbox"] {
+.mobooking-selectable-option input {
   opacity: 0;
   width: 0;
   height: 0;
   position: absolute;
 }
 
-.mobooking-checkbox-option span {
+.mobooking-selectable-option span {
   display: flex;
   align-items: center;
   gap: 0.75rem;
 }
 
-.mobooking-checkbox-option span::before {
+.mobooking-selectable-option span::before {
   content: '';
   display: inline-block;
   width: 18px;
   height: 18px;
   border: 2px solid hsl(var(--muted-foreground));
-  border-radius: var(--radius-sm);
   transition: all 0.2s ease;
   flex-shrink: 0;
+}
+
+.mobooking-checkbox-option span::before {
+  border-radius: var(--radius-sm);
+}
+
+.mobooking-radio-option span::before {
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 3px hsl(var(--background));
 }
 
 .mobooking-checkbox-option input[type="checkbox"]:checked + span::before {
@@ -360,59 +368,59 @@
   background-repeat: no-repeat;
 }
 
-.mobooking-checkbox-option input[type="checkbox"]:focus-visible + span::before {
-    box-shadow: 0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--ring));
-}
-
-/* Custom Radio Button Styles */
-.mobooking-radio-option {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
-  border-radius: var(--radius-sm);
-  border: 1px solid hsl(var(--border));
-  cursor: pointer;
-  transition: all 0.2s ease;
-  margin-bottom: 0.5rem;
-}
-
-.mobooking-radio-option:hover {
-  background-color: hsl(var(--accent));
-}
-
-.mobooking-radio-option input[type="radio"] {
-  opacity: 0;
-  width: 0;
-  height: 0;
-  position: absolute;
-}
-
-.mobooking-radio-option span {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.mobooking-radio-option span::before {
-  content: '';
-  display: inline-block;
-  width: 18px;
-  height: 18px;
-  border: 2px solid hsl(var(--muted-foreground));
-  border-radius: 50%;
-  transition: all 0.2s ease;
-  flex-shrink: 0;
-  box-shadow: inset 0 0 0 3px hsl(var(--background));
-}
-
 .mobooking-radio-option input[type="radio"]:checked + span::before {
   background-color: hsl(var(--ring));
   border-color: hsl(var(--ring));
 }
 
+.mobooking-checkbox-option input[type="checkbox"]:focus-visible + span::before {
+    box-shadow: 0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--ring));
+}
+
 .mobooking-radio-option input[type="radio"]:focus-visible + span::before {
     box-shadow: inset 0 0 0 3px hsl(var(--background)), 0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--ring));
+}
+
+/* Quantity Stepper */
+.mobooking-quantity-stepper {
+  display: flex;
+  align-items: center;
+  border: 1px solid hsl(var(--input));
+  border-radius: var(--radius-sm);
+  max-width: 150px;
+}
+
+.mobooking-quantity-stepper .form-input {
+  text-align: center;
+  border: none;
+  box-shadow: none;
+  padding: 0.5rem;
+  -moz-appearance: textfield;
+}
+.mobooking-quantity-stepper .form-input::-webkit-outer-spin-button,
+.mobooking-quantity-stepper .form-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.mobooking-quantity-stepper .stepper-btn {
+  background-color: transparent;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: hsl(var(--muted-foreground));
+  transition: background-color 0.2s;
+}
+
+.mobooking-quantity-stepper .stepper-btn:hover {
+  background-color: hsl(var(--accent));
+}
+
+.mobooking-quantity-stepper .stepper-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 /* Input Groups */

--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -745,7 +745,7 @@ jQuery(document).ready(function ($) {
           const value = v.value || v.label || v;
           const price = parseFloat(v.price) || 0;
           const cid = `mobooking-opt-${id}-${idx}`;
-          html += `<label class="mobooking-checkbox-option"><input type="checkbox" name="mobooking-option-${id}[]" id="${cid}" class="mobooking-option-input" data-type="checkbox" data-required="${isReq}" data-name="${escapeHtml(
+          html += `<label class="mobooking-checkbox-option mobooking-selectable-option"><input type="checkbox" name="mobooking-option-${id}[]" id="${cid}" class="mobooking-option-input" data-type="checkbox" data-required="${isReq}" data-name="${escapeHtml(
             name
           )}" value="${escapeHtml(
             value
@@ -779,7 +779,7 @@ jQuery(document).ready(function ($) {
           const value = v.value || v.label || v;
           const price = parseFloat(v.price) || 0;
           const rid = `mobooking-opt-${id}-${idx}`;
-          html += `<label class="mobooking-radio-option"><input type="radio" name="mobooking-option-${id}" id="${rid}" class="mobooking-option-input" data-type="radio" data-required="${isReq}" data-name="${escapeHtml(
+          html += `<label class="mobooking-radio-option mobooking-selectable-option"><input type="radio" name="mobooking-option-${id}" id="${rid}" class="mobooking-option-input" data-type="radio" data-required="${isReq}" data-name="${escapeHtml(
             name
           )}" value="${escapeHtml(
             value
@@ -789,8 +789,20 @@ jQuery(document).ready(function ($) {
         });
         if (opt.description)
           html += `<div class="mobooking-option-description">${escapeHtml(opt.description)}</div>`;
-      } else if (type === "number" || type === "quantity") {
-        html += `<input type="number" min="0" class="form-input mobooking-option-input" data-type="${type}" data-required="${isReq}" data-name="${escapeHtml(
+      } else if (type === "quantity") {
+        html += `<div class="mobooking-quantity-stepper">`;
+        html += `<button type="button" class="stepper-btn stepper-minus" aria-label="Decrease quantity">-</button>`;
+        html += `<input type="number" min="0" class="form-input mobooking-option-input" data-type="quantity" data-required="${isReq}" data-name="${escapeHtml(
+          name
+        )}" data-impact-type="${impactType}" data-impact-value="${impactValue}" value="${
+          isReq ? 1 : 0
+        }" readonly>`;
+        html += `<button type="button" class="stepper-btn stepper-plus" aria-label="Increase quantity">+</button>`;
+        html += `</div>`;
+        if (opt.description)
+          html += `<div class="mobooking-option-description">${escapeHtml(opt.description)}</div>`;
+      } else if (type === "number") {
+        html += `<input type="number" min="0" class="form-input mobooking-option-input" data-type="number" data-required="${isReq}" data-name="${escapeHtml(
           name
         )}" data-impact-type="${impactType}" data-impact-value="${impactValue}" value="${
           isReq ? 1 : 0
@@ -861,6 +873,34 @@ jQuery(document).ready(function ($) {
     collectOptionsAndPrice();
     updateLiveSummary();
   }
+
+  // Quantity Stepper Logic
+  $(document).on("click", ".stepper-btn", function () {
+    const $button = $(this);
+    const $input = $button.siblings('input[type="number"]');
+    if (!$input.length) return;
+
+    let currentValue = parseInt($input.val(), 10) || 0;
+    const min = parseInt($input.attr("min"), 10) || 0;
+
+    if ($button.hasClass("stepper-plus")) {
+      currentValue++;
+    } else if ($button.hasClass("stepper-minus")) {
+      currentValue--;
+    }
+
+    if (currentValue < min) {
+      currentValue = min;
+    }
+
+    $input.val(currentValue);
+
+    // Disable/enable buttons
+    $button.siblings(".stepper-minus").prop("disabled", currentValue === min);
+
+    // Trigger change event to update pricing
+    $input.trigger("change");
+  });
 
   function priceImpactLabel(type, value) {
     if (type === "percentage")


### PR DESCRIPTION
This commit refactors the styling of service options and adds a new quantity stepper UI component for an improved user experience.

Key changes include:
- Refactored the CSS in `assets/css/booking-form-modern.css` to use a shared class (`.mobooking-selectable-option`) for checkboxes and radio buttons, ensuring a consistent look and feel.
- Modified the `renderOptions` function in `assets/js/booking-form-public.js` to add the new shared class to checkbox and radio button labels.
- Implemented a quantity stepper UI component for 'quantity' type options.
  - Added HTML for plus/minus buttons in the `renderOptions` function.
  - Added CSS to style the new stepper component.
  - Added a JavaScript click handler to manage the stepper's functionality and trigger price recalculations.