### PR TITLE
fix: Prevent infinite loop in company slug generation

### DIFF
--- a/classes/Auth.php
+++ b/classes/Auth.php
@@ -674,15 +674,25 @@ public function handle_ajax_registration() {
                         $final_slug = $base_slug;
                         $counter = 1;
 
-                        while (\MoBooking\Classes\Routes\BookingFormRouter::get_user_id_by_slug($final_slug) !== 0) {
+                        error_log("MoBooking: Starting slug generation for base: {$base_slug}");
+
+                        // Loop until we find a slug that is not in use (get_user_id_by_slug returns null)
+                        while (\MoBooking\Classes\Routes\BookingFormRouter::get_user_id_by_slug($final_slug) !== null) {
                             $counter++;
                             $final_slug = $base_slug . '-' . $counter;
+                            error_log("MoBooking: Slug collision detected. Trying next slug: {$final_slug}");
+                            if ($counter > 50) { // Safety break to prevent accidental infinite loops in edge cases
+                                error_log("MoBooking: Slug generation loop exceeded 50 iterations. Breaking loop.");
+                                // Optionally, append a random string as a final attempt
+                                $final_slug .= '-' . wp_rand(100, 999);
+                                break;
+                            }
                         }
 
                         $settings_manager->update_setting($user_id, 'bf_business_slug', $final_slug);
-                        error_log("MoBooking: Business slug created: {$final_slug}");
+                        error_log("MoBooking: Business slug created and saved: {$final_slug}");
                     } catch (Exception $e) {
-                        error_log("MoBooking: Slug generation failed: " . $e->getMessage());
+                        error_log("MoBooking: Slug generation failed with exception: " . $e->getMessage());
                     }
                 }
             }


### PR DESCRIPTION
The registration process was timing out due to an infinite loop in the company slug generation logic. The `while` loop condition was incorrectly checking for `!== 0` instead of `!== null`, causing the loop to never terminate when a slug was not found.

This commit corrects the loop condition to `!== null`. It also adds more detailed logging and a safety break to the loop to prevent future issues and make the function more robust. This resolves the timeout issue during user registration.