### PR TITLE
feat: Implement hard validation for company name

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -360,14 +360,15 @@ jQuery(document).ready(function ($) {
                 DEBUG.log("Starting company slug existence check");
                 const slugCheck = await checkCompanySlugExists(registrationData.company_name);
                 if (slugCheck.exists) {
-                    // It's just a warning, not a validation failure, so we don't set isValid = false
                     showFieldError($("#mobooking-company-name"), slugCheck.message);
-                    DEBUG.log("Company name slug might be taken", { message: slugCheck.message });
+                    isValid = false; // This is now a hard validation error
+                    DEBUG.error("Company name validation failed: slug exists");
                 } else {
                     DEBUG.success("Company name appears to be available");
                 }
             } catch (error) {
                 DEBUG.error("Company slug check failed, continuing...", error);
+                // Optionally, you could block submission if the check fails, but for now we'll allow it.
             }
         } else {
           DEBUG.success("Company name validation passed (invitation flow or empty)");

--- a/classes/Auth.php
+++ b/classes/Auth.php
@@ -828,13 +828,10 @@ public function handle_ajax_registration() {
         $original_slug_check_user_id = \MoBooking\Classes\Routes\BookingFormRouter::get_user_id_by_slug($base_slug);
 
         if ($original_slug_check_user_id !== 0) {
-            // Slug already exists, suggest alternatives or just inform
-            // For simplicity, we'll just say it might be taken and will be suffixed.
-            // A more advanced version could try to find the next available -NUMBER suffix.
+            // Slug already exists, return a hard error message.
             wp_send_json_success([
                 'exists' => true,
-                'message' => __('This company name might already be in use or result in a similar URL. It will be made unique if necessary (e.g., by adding a number).', 'mobooking'),
-                'slug_preview' => $base_slug . '-2' // Example suffix
+                'message' => __('This company name is already taken. Please choose another.', 'mobooking')
             ]);
         } else {
             wp_send_json_success([


### PR DESCRIPTION
Implements stricter validation for the "Company Name" field on the registration form to prevent duplicate entries.

- The backend AJAX handler in `classes/Auth.php` now returns a hard error message if a company name's slug already exists.
- The frontend JavaScript in `assets/js/auth.js` now treats this as a blocking validation error, preventing the user from proceeding with registration until they provide a unique company name.