### PR TITLE
fix: Correct validation condition for company slug check

### DIFF
--- a/classes/Auth.php
+++ b/classes/Auth.php
@@ -827,7 +827,7 @@ public function handle_ajax_registration() {
         $base_slug = sanitize_title($company_name);
         $original_slug_check_user_id = \MoBooking\Classes\Routes\BookingFormRouter::get_user_id_by_slug($base_slug);
 
-        if ($original_slug_check_user_id !== 0) {
+        if ($original_slug_check_user_id !== null) {
             // Slug already exists, return a hard error message.
             wp_send_json_success([
                 'exists' => true,


### PR DESCRIPTION
The AJAX handler for checking company name existence was using an incorrect condition (`!== 0` instead of `!== null`) to check the result from the `get_user_id_by_slug` function. This caused the validation to always fail, incorrectly reporting that every company name was already taken.

This commit corrects the condition to `!== null`, ensuring the validation works as intended.