### PR TITLE
Fix service sorting and placeholder styling

### DIFF
--- a/assets/css/dashboard-services-redesigned.css
+++ b/assets/css/dashboard-services-redesigned.css
@@ -395,6 +395,14 @@
     border: 1px solid hsl(var(--mobk-primary));
 }
 
+.service-list-item-placeholder {
+    height: 60px;
+    background-color: hsl(var(--mobk-muted));
+    border: 2px dashed hsl(var(--mobk-border));
+    border-radius: var(--mobk-radius);
+    margin-bottom: 0.5rem;
+}
+
 /* ============================================================================
    Responsive Design
    ============================================================================ */

--- a/dashboard/page-services.php
+++ b/dashboard/page-services.php
@@ -21,7 +21,7 @@ $default_args = [
     'number' => 20,
     'offset' => 0,
     'status' => null,
-    'orderby' => 'name',
+    'orderby' => 'sort_order',
     'order' => 'ASC',
 ];
 


### PR DESCRIPTION
The service sorting feature was not working because the services were not being ordered by the `sort_order` column on page load. This commit fixes the initial query to use the correct ordering.

It also adds styling for the placeholder element that appears when dragging and dropping services.