### PR TITLE
Fix service sorting and display options on booking form

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -604,17 +604,15 @@ jQuery(document).ready(function ($) {
         svc
       )}' style="position:absolute;opacity:0;pointer-events:none;">
           <div class="mobooking-service-header">
-            ${
-              CONFIG.settings.service_card_display === "icon" && svc.icon
-                ? `<div class="mobooking-service-icon"><img src="${
-                    svc.icon
-                  }" alt="${escapeHtml(svc.name)}"></div>`
-                : svc.image_url
-                ? `<div class="mobooking-service-image"><img src="${
-                    svc.image_url
-                  }" alt="${escapeHtml(svc.name)}"></div>`
-                : ""
-            }
+            ${(() => {
+                if (CONFIG.settings.bf_service_card_display === 'icon' && svc.icon) {
+                    return `<div class="mobooking-service-icon">${svc.icon}</div>`;
+                }
+                if (CONFIG.settings.bf_service_card_display === 'image' && svc.image_url) {
+                    return `<div class="mobooking-service-image"><img src="${svc.image_url}" alt="${escapeHtml(svc.name)}"></div>`;
+                }
+                return '';
+            })()}
             <div style="flex:1;">
               <div class="mobooking-service-title">${escapeHtml(svc.name)}</div>
               ${

--- a/classes/Services.php
+++ b/classes/Services.php
@@ -732,7 +732,7 @@ public function handle_get_public_services_ajax() {
         
         // Get all active services for this user
         $all_services = $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT * FROM $table_name WHERE user_id = %d AND status = 'active' ORDER BY name ASC",
+            "SELECT * FROM $table_name WHERE user_id = %d AND status = 'active' ORDER BY sort_order ASC",
             $tenant_id
         ), ARRAY_A);
         

--- a/functions/theme-setup.php
+++ b/functions/theme-setup.php
@@ -273,6 +273,7 @@ if ( is_page_template('templates/booking-form-public.php') || $page_type_for_scr
             'bf_form_enabled' => $tenant_settings['bf_form_enabled'] ?? '1',
             'bf_maintenance_message' => isset($tenant_settings['bf_maintenance_message']) ? esc_js($tenant_settings['bf_maintenance_message']) : '',
             'bf_enable_location_check' => $tenant_settings['bf_enable_location_check'] ?? '1',
+            'bf_service_card_display' => $tenant_settings['bf_service_card_display'] ?? 'image',
             // Add any other settings, ensuring strings that might contain problematic characters are escaped
             // For example, if there were other free-text fields:
             // 'another_free_text_setting' => isset($tenant_settings['another_free_text_setting']) ? esc_js($tenant_settings['another_free_text_setting']) : '',


### PR DESCRIPTION
- The services on the public booking form are now sorted according to the order set in the dashboard.
- The 'Service Card Display' options (Show Image/Show Icon) on the booking form settings page now work correctly.