### PR TITLE
Fix service sorting and display options on booking form

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -536,7 +536,7 @@ jQuery(document).ready(function ($) {
     `);
 
     $.post(CONFIG.ajax_url, {
-      action: "mobooking_get_services",
+      action: "mobooking_get_public_services",
       nonce: CONFIG.nonce,
       tenant_id: CONFIG.tenant_id,
     })

--- a/classes/Services.php
+++ b/classes/Services.php
@@ -764,6 +764,7 @@ public function handle_get_public_services_ajax() {
                 $item['name'] = sanitize_text_field($item['name']);
                 $item['description'] = wp_kses_post($item['description']);
                 $item['category'] = sanitize_text_field($item['category'] ?? '');
+                $item['icon'] = $this->get_service_icon_html($item['icon']);
                 
                 // Get service options if they exist
                 $options_raw = $this->service_options_manager->get_service_options($item['service_id'], $tenant_id);


### PR DESCRIPTION
- The services on the public booking form are now sorted according to the order set in the dashboard.
- The 'Service Card Display' options (Show Image/Show Icon) on the booking form settings page now work correctly.
- The icon rendering on the booking form is also fixed.