### PR TITLE
Fix service sorting and display options on booking form

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -606,7 +606,7 @@ jQuery(document).ready(function ($) {
           <div class="mobooking-service-header">
             ${(() => {
                 if (CONFIG.settings.bf_service_card_display === 'icon' && svc.icon) {
-                    return `<div class="mobooking-service-icon">${svc.icon}</div>`;
+                    return svc.icon;
                 }
                 if (CONFIG.settings.bf_service_card_display === 'image' && svc.image_url) {
                     return `<div class="mobooking-service-image"><img src="${svc.image_url}" alt="${escapeHtml(svc.name)}"></div>`;


### PR DESCRIPTION
- The services on the public booking form are now sorted according to the order set in the dashboard.
- The 'Service Card Display' options (Show Image/Show Icon) on the booking form settings page now work correctly.
- The icon rendering on the booking form is also fixed.