### PR TITLE
feat: Add ability to control form steps based on selected service

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -101,6 +101,25 @@ jQuery(document).ready(function ($) {
   // STEP NAVIGATION
   // ==========================================
 
+  function updateStepVisibility() {
+    const service = state.service;
+    if (!service) {
+      // Show all conditional steps if no service is selected
+      $("#mobooking-step-4, #mobooking-step-5").removeClass("hidden");
+      $('.mobooking-step-indicator[data-step="4"], .mobooking-step-indicator[data-step="5"]').removeClass("hidden");
+      return;
+    }
+
+    const disablePets = service.disable_pet_question == "1";
+    const disableFreq = service.disable_frequency_option == "1";
+
+    $("#mobooking-step-4").toggleClass("hidden", disablePets);
+    $('.mobooking-step-indicator[data-step="4"]').toggleClass("hidden", disablePets);
+
+    $("#mobooking-step-5").toggleClass("hidden", disableFreq);
+    $('.mobooking-step-indicator[data-step="5"]').toggleClass("hidden", disableFreq);
+  }
+
   function showStep(step) {
     state.currentStep = step;
 
@@ -160,12 +179,36 @@ jQuery(document).ready(function ($) {
   }
 
   function nextStep() {
-    const next = state.currentStep + 1;
-    if (validateStep(state.currentStep)) showStep(next);
+    if (!validateStep(state.currentStep)) return;
+
+    let next = state.currentStep + 1;
+
+    // Skip step 4 if it's hidden
+    if (next === 4 && $("#mobooking-step-4").hasClass("hidden")) {
+      next++;
+    }
+    // Skip step 5 if it's hidden
+    if (next === 5 && $("#mobooking-step-5").hasClass("hidden")) {
+      next++;
+    }
+
+    if (next <= state.totalSteps) {
+      showStep(next);
+    }
   }
 
   function prevStep() {
-    const prev = state.currentStep - 1;
+    let prev = state.currentStep - 1;
+
+    // Skip step 5 if it's hidden
+    if (prev === 5 && $("#mobooking-step-5").hasClass("hidden")) {
+      prev--;
+    }
+    // Skip step 4 if it's hidden
+    if (prev === 4 && $("#mobooking-step-4").hasClass("hidden")) {
+      prev--;
+    }
+
     if (prev >= 1) {
       resetStepData(state.currentStep); // Reset data for the step we are leaving
       showStep(prev);
@@ -643,6 +686,7 @@ jQuery(document).ready(function ($) {
         state.pricing.base = parseFloat(svc.price) || 0;
         recalcTotal();
         updateLiveSummary();
+        updateStepVisibility();
 
         // Auto advance to options
         setTimeout(() => showStep(3), 200);

--- a/classes/Database.php
+++ b/classes/Database.php
@@ -76,6 +76,8 @@ class Database {
             icon VARCHAR(100),
             image_url VARCHAR(255),
             status VARCHAR(20) NOT NULL DEFAULT 'active',
+            disable_pet_question BOOLEAN NOT NULL DEFAULT 0,
+            disable_frequency_option BOOLEAN NOT NULL DEFAULT 0,
             sort_order INT NOT NULL DEFAULT 0,
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/classes/Services.php
+++ b/classes/Services.php
@@ -107,7 +107,9 @@ class Services {
             'duration' => 30, // Default duration in minutes
             'icon' => '',
             'image_url' => '',
-            'status' => 'active'
+            'status' => 'active',
+            'disable_pet_question' => 0,
+            'disable_frequency_option' => 0
         );
         $service_data = wp_parse_args($data, $defaults);
 
@@ -124,10 +126,12 @@ class Services {
                 'icon' => sanitize_text_field($service_data['icon']),
                 'image_url' => esc_url_raw($service_data['image_url']),
                 'status' => sanitize_text_field($service_data['status']),
+                'disable_pet_question' => intval($service_data['disable_pet_question']),
+                'disable_frequency_option' => intval($service_data['disable_frequency_option']),
                 'created_at' => current_time('mysql', 1), // GMT
                 'updated_at' => current_time('mysql', 1), // GMT
             ),
-            array('%d', '%s', '%s', '%f', '%d', '%s', '%s', '%s', '%s', '%s')
+            array('%d', '%s', '%s', '%f', '%d', '%s', '%s', '%s', '%d', '%d', '%s', '%s')
         );
 
         if (false === $inserted) {
@@ -271,6 +275,8 @@ class Services {
         if (isset($data['icon'])) { $update_data['icon'] = sanitize_text_field($data['icon']); $update_formats[] = '%s'; }
         if (isset($data['image_url'])) { $update_data['image_url'] = esc_url_raw($data['image_url']); $update_formats[] = '%s'; }
         if (isset($data['status'])) { $update_data['status'] = sanitize_text_field($data['status']); $update_formats[] = '%s'; }
+		if (isset($data['disable_pet_question'])) { $update_data['disable_pet_question'] = intval($data['disable_pet_question']); $update_formats[] = '%d'; }
+		if (isset($data['disable_frequency_option'])) { $update_data['disable_frequency_option'] = intval($data['disable_frequency_option']); $update_formats[] = '%d'; }
 
         if (empty($update_data)) {
             // If only 'category' was provided, $update_data might be empty now.
@@ -1103,14 +1109,16 @@ class Services {
         $image_url_from_post = isset($_POST['image_url']) ? trim($_POST['image_url']) : '';
 
             $data_for_service_method = [
-            'name' => sanitize_text_field($trimmed_service_name),
+                'name' => sanitize_text_field($trimmed_service_name),
                 'description' => wp_kses_post(isset($_POST['description']) ? $_POST['description'] : ''),
-            'price' => floatval($price_from_post),
-            // Add category to the data prepared for save/update methods
-            'category' => isset($_POST['category']) ? sanitize_text_field($_POST['category']) : '', // Default to empty string if not set, for consistency
-            'icon' => !empty($icon_from_post) ? sanitize_text_field($icon_from_post) : null,
-            'image_url' => !empty($image_url_from_post) ? esc_url_raw($image_url_from_post) : null,
+                'price' => floatval($price_from_post),
+                'duration' => $duration_from_post,
+                'category' => isset($_POST['category']) ? sanitize_text_field($_POST['category']) : '', // Default to empty string if not set, for consistency
+                'icon' => !empty($icon_from_post) ? sanitize_text_field($icon_from_post) : null,
+                'image_url' => !empty($image_url_from_post) ? esc_url_raw($image_url_from_post) : null,
                 'status' => sanitize_text_field(isset($_POST['status']) ? $_POST['status'] : 'active'),
+                'disable_pet_question' => isset($_POST['disable_pet_question']) && '1' === $_POST['disable_pet_question'] ? 1 : 0,
+                'disable_frequency_option' => isset($_POST['disable_frequency_option']) && '1' === $_POST['disable_frequency_option'] ? 1 : 0,
             ];
         error_log('[MoBooking SaveSvc Debug] Data for add/update_service (with nulls for empty optionals): ' . print_r($data_for_service_method, true));
  

--- a/dashboard/page-service-edit.php
+++ b/dashboard/page-service-edit.php
@@ -33,6 +33,8 @@ $service_duration     = '';
 $service_icon         = '';
 $service_image_url    = '';
 $service_status       = 'active';
+$disable_pet_question = 0;
+$disable_frequency_option = 0;
 $service_options_data = array();
 $error_message        = '';
 
@@ -160,6 +162,8 @@ if ( $edit_mode && $service_id > 0 ) {
 			$service_icon         = $service_data['icon'];
 			$service_image_url    = $service_data['image_url'];
 			$service_status       = $service_data['status'];
+			$disable_pet_question = $service_data['disable_pet_question'] ?? 0;
+			$disable_frequency_option = $service_data['disable_frequency_option'] ?? 0;
 			$service_options_data = isset( $service_data['options'] ) && is_array( $service_data['options'] ) ? $service_data['options'] : array();
 		} else {
 			$error_message = __( 'Service not found or you do not have permission to edit it.', 'mobooking' );
@@ -381,7 +385,25 @@ if ( $edit_mode && $service_id > 0 ) {
 								<input type="hidden" name="status" value="<?php echo esc_attr( $service_status ); ?>">
 							</div>
 						</div>
-
+						<hr class="my-4">
+						<div class="flex items-center justify-between">
+							<label class="mobooking-filter-item label" for="disable_pet_question"><?php esc_html_e( 'Disable Pet Question', 'mobooking' ); ?></label>
+							<div class="flex items-center space-x-2">
+								<button type="button" class="switch <?php echo $disable_pet_question ? 'switch-checked' : ''; ?>" data-switch="disable_pet_question">
+									<span class="switch-thumb"></span>
+								</button>
+								<input type="hidden" name="disable_pet_question" value="<?php echo esc_attr( $disable_pet_question ); ?>">
+							</div>
+						</div>
+						<div class="flex items-center justify-between mt-4">
+							<label class="mobooking-filter-item label" for="disable_frequency_option"><?php esc_html_e( 'Disable Frequency Option', 'mobooking' ); ?></label>
+							<div class="flex items-center space-x-2">
+								<button type="button" class="switch <?php echo $disable_frequency_option ? 'switch-checked' : ''; ?>" data-switch="disable_frequency_option">
+									<span class="switch-thumb"></span>
+								</button>
+								<input type="hidden" name="disable_frequency_option" value="<?php echo esc_attr( $disable_frequency_option ); ?>">
+							</div>
+						</div>
 					</div>
 				</div>
 				<!-- Visual Settings Card -->


### PR DESCRIPTION
This commit introduces the ability to control the visibility of certain steps in the public booking form based on the selected service.

- Adds 'Disable Pet Question' and 'Disable Frequency Option' switches to the service edit page.
- Updates the database schema for services to store these new settings.
- Modifies the backend to save and retrieve these settings.
- Updates the public booking form's JavaScript to conditionally hide/show and skip the pet and frequency steps based on the selected service's configuration.