### PR TITLE
fix: Ensure correct AJAX handler sends step-skipping flags

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1111,7 +1111,7 @@ function mobooking_direct_services_handler() {
     $services_table = $wpdb->prefix . 'mobooking_services';
     
     $services = $wpdb->get_results($wpdb->prepare(
-        "SELECT service_id, name, description, price, duration, icon, image_url 
+        "SELECT service_id, name, description, price, duration, icon, image_url, disable_pet_question, disable_frequency_option
          FROM $services_table 
          WHERE user_id = %d AND status = 'active' 
          ORDER BY name ASC",
@@ -1132,7 +1132,9 @@ function mobooking_direct_services_handler() {
             'price' => floatval($service['price']),
             'duration' => intval($service['duration']),
             'icon' => $service['icon'],
-            'image_url' => $service['image_url']
+            'image_url' => $service['image_url'],
+            'disable_pet_question' => $service['disable_pet_question'],
+            'disable_frequency_option' => $service['disable_frequency_option']
         ];
     }
 


### PR DESCRIPTION
This commit fixes a bug where the 'Disable Pet Question' and 'Disable Frequency Option' settings were not being applied to the public booking form.

The issue was that a secondary, more aggressively loaded AJAX handler (`mobooking_override_handler`) was overriding the previously patched function. This active handler was not selecting or returning the new `disable_pet_question` and `disable_frequency_option` fields from the database.

This has been corrected by updating the `SELECT` query and the returned data array in the `mobooking_override_handler` function within `functions.php`, ensuring the frontend receives the necessary flags to control step visibility.