### PR TITLE
feat: Make ZIP input editable when location check is disabled

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -1477,6 +1477,20 @@ jQuery(document).ready(function ($) {
   // If step 1 is disabled, start at step 2
   const startStep = $("#mobooking-step-1").length ? 1 : 2;
 
+  // If location check is disabled, make the ZIP input in step 7 editable
+  if (
+    !CONFIG.settings?.bf_enable_location_check ||
+    CONFIG.settings.bf_enable_location_check === "0"
+  ) {
+    const zipInput = $("#mobooking-zip-readonly");
+    zipInput.prop("readonly", false);
+
+    // Also, update state when user types in their zip
+    zipInput.on("input", function () {
+      state.zip = $(this).val();
+    });
+  }
+
   // Add collapsible classes
   els.timeSlotsWrap.addClass("mobooking-collapsible is-collapsed");
   $("#mobooking-custom-access-details").addClass(


### PR DESCRIPTION
When the "first step zipcode check" is disabled, the ZIP/Postal Code input field in the customer details step was still readonly, preventing users from entering their ZIP code.

This change makes the input field editable if the location check is disabled and ensures the entered value is stored in the application state.