### PR TITLE
feat: Improve form behavior when location check is disabled

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -1489,6 +1489,9 @@ jQuery(document).ready(function ($) {
     zipInput.on("input", function () {
       state.zip = $(this).val();
     });
+
+    // Also, hide the "previous" button on step 2, as there's no step 1
+    $("#mobooking-step-2 .mobooking-btn-secondary").hide();
   }
 
   // Add collapsible classes


### PR DESCRIPTION
When the "first step zipcode check" is disabled, two issues were present:
1. The ZIP/Postal Code input field in the customer details step was still readonly.
2. The back button was still visible on the first visible step (step 2).

This change addresses both issues. It makes the ZIP input field editable and hides the back button on step 2 when the location check is disabled. It also ensures the entered ZIP is stored in the application state.