### PR TITLE
feat: Make ZIP input editable when location check is disabled

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -1490,8 +1490,6 @@ jQuery(document).ready(function ($) {
       state.zip = $(this).val();
     });
 
-    // Also, hide the "previous" button on step 2, as there's no step 1
-    $("#mobooking-step-2 .mobooking-btn-secondary").hide();
   }
 
   // Add collapsible classes


### PR DESCRIPTION
When the "first step zipcode check" is disabled, the ZIP/Postal Code input field in the customer details step was still readonly, preventing users from entering their ZIP code.

This change makes the input field editable if the location check is disabled and ensures the entered value is stored in the application state.