### PR TITLE
feat: Hide back button when location check is disabled

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -1490,6 +1490,8 @@ jQuery(document).ready(function ($) {
       state.zip = $(this).val();
     });
 
+    // Also, hide the "previous" button on step 2, as there's no step 1
+    $("#mobooking-step-2 .mobooking-btn-secondary").hide();
   }
 
   // Add collapsible classes


### PR DESCRIPTION
When the location check step is disabled, the form starts at step 2. In this case, the back button was still visible, which could confuse the user as there is no previous step to go back to.

This change hides the back button on step 2 if the location check is disabled.