### PR TITLE
feat: Add progress bar style option and enhance step display

### DIFF
--- a/assets/css/booking-form-refactored.css
+++ b/assets/css/booking-form-refactored.css
@@ -132,6 +132,33 @@ body {
     overflow: hidden;
 }
 
+/* Progress Bar Only Style */
+.progress-style-bar .mobooking-progress-bar {
+    height: 12px;
+    border-radius: 6px;
+}
+
+/* Steps with Labels Style */
+.progress-style-steps .mobooking-progress-bar {
+    height: 4px;
+    margin-top: 0.5rem;
+}
+
+.progress-style-steps .mobooking-step-indicator {
+    position: relative;
+}
+
+.progress-style-steps .mobooking-step-indicator::after {
+    content: attr(data-label);
+    position: absolute;
+    bottom: -1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+    white-space: nowrap;
+}
+
 .mobooking-progress-fill {
     height: 100%;
     background-color: hsl(var(--primary));

--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -17,7 +17,7 @@ class Settings {
                 'bf_font_family'              => 'system-ui',
                 'bf_border_radius'            => '8',
                 'bf_header_text'              => 'Book Our Services Online',
-                'bf_show_progress_bar'        => '1',
+                'bf_progress_display_style'   => 'steps',
                 'bf_allow_cancellation_hours' => '24',
                 'bf_custom_css'               => '',
                 'bf_terms_conditions_url'     => '',
@@ -344,6 +344,10 @@ private function validate_and_sanitize_booking_form_settings($settings_data) {
         'bf_enable_location_check' => [ // Added for explicit boolean handling
             'type' => 'boolean'
         ],
+        'bf_progress_display_style' => [
+            'type' => 'choice',
+            'choices' => ['steps', 'bar', 'none']
+        ],
         'bf_service_card_display' => [
             'type' => 'text'
         ]
@@ -399,6 +403,13 @@ private function sanitize_field_value($value, $rules) {
         case 'color':
             $sanitized = sanitize_hex_color($value);
             return $sanitized ?: '';
+
+        case 'choice':
+            if (isset($rules['choices']) && in_array($value, $rules['choices'], true)) {
+                return $value;
+            }
+            // Return the first choice as default if the provided value is invalid
+            return $rules['choices'][0] ?? '';
 
         case 'boolean':
             return in_array($value, ['1', 'true', true, 1], true) ? '1' : '0';

--- a/dashboard/page-booking-form.php
+++ b/dashboard/page-booking-form.php
@@ -215,15 +215,29 @@ if (!empty($current_slug)) {
                                             <textarea name="bf_description" id="bf_description" class="form-textarea" rows="3"><?php echo mobooking_get_setting_textarea($bf_settings, 'bf_description'); ?></textarea>
                                             <p class="description"><?php esc_html_e('Optional description text shown below the header.', 'mobooking'); ?></p>
                                         </div>
-                                        <div class="form-group form-group-toggle">
-                                            <label class="mobooking-toggle-switch">
-                                                <input name="bf_show_progress_bar" type="checkbox" id="bf_show_progress_bar" value="1" <?php echo mobooking_is_setting_checked($bf_settings, 'bf_show_progress_bar', true); ?>>
-                                                <span class="slider"></span>
-                                            </label>
-                                            <div class="toggle-label-group">
-                                                <label for="bf_show_progress_bar" class="toggle-label"><?php esc_html_e('Show Progress Bar', 'mobooking'); ?></label>
-                                                <p class="description"><?php esc_html_e('Display a progress indicator showing the current step in the booking process.', 'mobooking'); ?></p>
+                                        <div class="form-group">
+                                            <label><?php esc_html_e('Progress Indicator Style', 'mobooking'); ?></label>
+                                            <div class="mobooking-radio-group-cards">
+                                                <label>
+                                                    <input type="radio" name="bf_progress_display_style" value="steps" <?php checked(mobooking_get_setting_value($bf_settings, 'bf_progress_display_style', 'steps'), 'steps'); ?>>
+                                                    <div class="card-content">
+                                                        <span><?php esc_html_e('Steps with Labels', 'mobooking'); ?></span>
+                                                    </div>
+                                                </label>
+                                                <label>
+                                                    <input type="radio" name="bf_progress_display_style" value="bar" <?php checked(mobooking_get_setting_value($bf_settings, 'bf_progress_display_style', 'steps'), 'bar'); ?>>
+                                                    <div class="card-content">
+                                                        <span><?php esc_html_e('Progress Bar', 'mobooking'); ?></span>
+                                                    </div>
+                                                </label>
+                                                <label>
+                                                    <input type="radio" name="bf_progress_display_style" value="none" <?php checked(mobooking_get_setting_value($bf_settings, 'bf_progress_display_style', 'steps'), 'none'); ?>>
+                                                    <div class="card-content">
+                                                        <span><?php esc_html_e('None', 'mobooking'); ?></span>
+                                                    </div>
+                                                </label>
                                             </div>
+                                            <p class="description"><?php esc_html_e('Choose how to display the progress indicator on the booking form.', 'mobooking'); ?></p>
                                         </div>
                                         <div class="form-group">
                                             <label><?php esc_html_e('Service Card Display', 'mobooking'); ?></label>
@@ -295,11 +309,18 @@ if (!empty($current_slug)) {
                                     <div class="mobooking-form-preview-wrapper">
                                         <div class="mobooking-form-preview">
                                             <div class="preview-header">
-                                                <h2 id="preview-header-text"><?php echo esc_html(mobooking_get_setting_value($bf_settings, 'bf_header_text', 'Book Our Services Online')); ?></h2>
+                                             <h2 id="preview-header-text"><?php echo esc_html(mobooking_get_setting_value($bf_settings, 'bf_header_text', 'Book Our Services Online')); ?></h2>
                                                 <p id="preview-description"><?php echo esc_html(mobooking_get_setting_value($bf_settings, 'bf_description')); ?></p>
                                             </div>
-                                            <div class="preview-progress-bar" style="<?php echo mobooking_is_setting_checked($bf_settings, 'bf_show_progress_bar', true) ? '' : 'display: none;'; ?>">
-                                                <div class="preview-progress-fill"></div>
+                                            <div class="preview-progress-wrapper" style="padding: 1rem 0; min-height: 50px;">
+                                                <div class="preview-progress-steps" style="display: flex; justify-content: space-between; margin-bottom: 1rem;">
+                                                    <div class="mobooking-step-indicator active" style="position: relative;">1 <span class="step-label">Service</span></div>
+                                                    <div class="mobooking-step-indicator" style="position: relative;">2 <span class="step-label">Options</span></div>
+                                                    <div class="mobooking-step-indicator" style="position: relative;">3 <span class="step-label">Details</span></div>
+                                                </div>
+                                                <div class="preview-progress-bar" style="height: 8px; background-color: #e5e7eb; border-radius: 4px; overflow: hidden;">
+                                                    <div class="preview-progress-fill" style="width: 25%; height: 100%; background-color: var(--preview-primary, #1abc9c);"></div>
+                                                </div>
                                             </div>
                                             <div class="preview-form-content">
                                                 <div class="preview-service-card">
@@ -643,6 +664,17 @@ if (!empty($current_slug)) {
     word-wrap: break-word;
 }
 
+.preview-progress-steps .mobooking-step-indicator .step-label {
+    display: block;
+    font-size: 0.7rem;
+    position: absolute;
+    bottom: -1.2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    color: #6b7280;
+    white-space: nowrap;
+}
+
 .preview-progress-bar {
     width: 100%;
     height: 8px;
@@ -723,3 +755,44 @@ if (!empty($current_slug)) {
     }
 }
 </style>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const progressStyleRadios = document.querySelectorAll('input[name="bf_progress_display_style"]');
+    const previewWrapper = document.querySelector('.preview-progress-wrapper');
+    const previewSteps = document.querySelector('.preview-progress-steps');
+    const previewBar = document.querySelector('.preview-progress-bar');
+
+    function updatePreview(style) {
+        if (!previewWrapper || !previewSteps || !previewBar) return;
+
+        // Reset styles to default (steps view)
+        previewWrapper.style.display = 'block';
+        previewSteps.style.display = 'flex';
+        previewBar.style.height = '8px';
+        previewBar.style.marginTop = '1rem';
+
+        switch(style) {
+            case 'bar':
+                previewSteps.style.display = 'none';
+                previewBar.style.height = '12px';
+                previewBar.style.marginTop = '0.5rem';
+                break;
+            case 'none':
+                previewWrapper.style.display = 'none';
+                break;
+        }
+    }
+
+    progressStyleRadios.forEach(function(radio) {
+        radio.addEventListener('change', function() {
+            updatePreview(this.value);
+        });
+    });
+
+    // Initial update on page load
+    const initialStyleEl = document.querySelector('input[name="bf_progress_display_style"]:checked');
+    if (initialStyleEl) {
+        updatePreview(initialStyleEl.value);
+    }
+});
+</script>

--- a/templates/booking-form-public.php
+++ b/templates/booking-form-public.php
@@ -55,7 +55,7 @@ $form_config = [
     'form_enabled' => ($bf_settings['bf_form_enabled'] ?? '1') === '1',
     'theme_color' => $bf_settings['bf_theme_color'] ?? '#1abc9c',
     'header_text' => $bf_settings['bf_header_text'] ?? 'Book Our Services Online',
-    'show_progress_bar' => ($bf_settings['bf_show_progress_bar'] ?? '1') === '1',
+    'progress_display_style' => $bf_settings['bf_progress_display_style'] ?? 'steps',
     'success_message' => $bf_settings['bf_success_message'] ?? 'Thank you for your booking! We will contact you soon to confirm the details.',
     'service_card_display' => $bf_settings['bf_service_card_display'] ?? 'image',
 ];
@@ -111,10 +111,31 @@ $script_data = [
     </div>
 
     <!-- Progress Bar -->
-    <?php if ($form_config['show_progress_bar']): ?>
-    <div class="mobooking-progress-container" id="mobooking-progress-container">
+    <?php
+    $progress_style = $bf_settings['bf_progress_display_style'] ?? 'steps';
+
+    // Backwards compatibility:
+    // If the new style setting has its default value ('steps') and the old 'show_progress_bar' setting was explicitly set to '0' (off),
+    // then we assume the user wanted it off and set the style to 'none'.
+    if ($progress_style === 'steps' && isset($bf_settings['bf_show_progress_bar']) && $bf_settings['bf_show_progress_bar'] === '0') {
+        $progress_style = 'none';
+    }
+    ?>
+    <?php if ($progress_style !== 'none'): ?>
+    <div class="mobooking-progress-container progress-style-<?php echo esc_attr($progress_style); ?>" id="mobooking-progress-container">
+        <?php if ($progress_style === 'steps'): ?>
         <div class="mobooking-progress-steps">
             <?php
+            $step_labels = [
+                1 => __('Area', 'mobooking'),
+                2 => __('Service', 'mobooking'),
+                3 => __('Options', 'mobooking'),
+                4 => __('Pets', 'mobooking'),
+                5 => __('Frequency', 'mobooking'),
+                6 => __('Date & Time', 'mobooking'),
+                7 => __('Details', 'mobooking'),
+                8 => __('Confirm', 'mobooking'),
+            ];
             $total_steps = 8;
             $visible_steps = [];
 
@@ -131,11 +152,12 @@ $script_data = [
 
             foreach ($visible_steps as $i => $step):
             ?>
-            <div class="mobooking-step-indicator <?php echo $i === 0 ? 'active' : ''; ?>" data-step="<?php echo $step; ?>">
+            <div class="mobooking-step-indicator <?php echo $i === 0 ? 'active' : ''; ?>" data-step="<?php echo $step; ?>" data-label="<?php echo esc_attr($step_labels[$step]); ?>">
                 <?php echo $step; ?>
             </div>
             <?php endforeach; ?>
         </div>
+        <?php endif; ?>
         <div class="mobooking-progress-bar">
             <div class="mobooking-progress-fill" id="mobooking-progress-fill"></div>
         </div>


### PR DESCRIPTION
This commit introduces a new display option for the multi-step form's progress indicator, allowing administrators to choose between the existing step-based view and a new, cleaner progress bar view.

Key changes:

- **New Setting:** Added a 'Progress Indicator Style' setting in the Form Appearance section of the dashboard. This replaces the old 'Show Progress Bar' toggle with a choice between 'Steps with Labels', 'Progress Bar', or 'None'.
- **Enhanced Step View:** The default 'Steps with Labels' view now includes text labels under each step number for better clarity.
- **Progress Bar View:** The 'Progress Bar' option displays a simple, prominent bar that fills as the user progresses through the form, offering a more modern and minimalist look.
- **Live Preview:** The admin settings page now includes a dynamic live preview that updates instantly to show how each progress indicator style will look on the form.
- **Backward Compatibility:** The old `bf_show_progress_bar` setting is handled gracefully. If a user had the progress bar disabled, the form will respect that choice by defaulting to the 'None' style.