### PR TITLE
refactor: Simplify progress indicator to be a progress bar or none

### DIFF
--- a/assets/css/booking-form-refactored.css
+++ b/assets/css/booking-form-refactored.css
@@ -138,26 +138,6 @@ body {
     border-radius: 6px;
 }
 
-/* Steps with Labels Style */
-.progress-style-steps .mobooking-progress-bar {
-    height: 4px;
-    margin-top: 0.5rem;
-}
-
-.progress-style-steps .mobooking-step-indicator {
-    position: relative;
-}
-
-.progress-style-steps .mobooking-step-indicator::after {
-    content: attr(data-label);
-    position: absolute;
-    bottom: -1.5rem;
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 0.75rem;
-    color: hsl(var(--muted-foreground));
-    white-space: nowrap;
-}
 
 .mobooking-progress-fill {
     height: 100%;

--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -17,7 +17,7 @@ class Settings {
                 'bf_font_family'              => 'system-ui',
                 'bf_border_radius'            => '8',
                 'bf_header_text'              => 'Book Our Services Online',
-                'bf_progress_display_style'   => 'steps',
+                'bf_progress_display_style'   => 'bar',
                 'bf_allow_cancellation_hours' => '24',
                 'bf_custom_css'               => '',
                 'bf_terms_conditions_url'     => '',
@@ -346,7 +346,7 @@ private function validate_and_sanitize_booking_form_settings($settings_data) {
         ],
         'bf_progress_display_style' => [
             'type' => 'choice',
-            'choices' => ['steps', 'bar', 'none']
+            'choices' => ['bar', 'none']
         ],
         'bf_service_card_display' => [
             'type' => 'text'

--- a/dashboard/page-booking-form.php
+++ b/dashboard/page-booking-form.php
@@ -219,19 +219,13 @@ if (!empty($current_slug)) {
                                             <label><?php esc_html_e('Progress Indicator Style', 'mobooking'); ?></label>
                                             <div class="mobooking-radio-group-cards">
                                                 <label>
-                                                    <input type="radio" name="bf_progress_display_style" value="steps" <?php checked(mobooking_get_setting_value($bf_settings, 'bf_progress_display_style', 'steps'), 'steps'); ?>>
-                                                    <div class="card-content">
-                                                        <span><?php esc_html_e('Steps with Labels', 'mobooking'); ?></span>
-                                                    </div>
-                                                </label>
-                                                <label>
-                                                    <input type="radio" name="bf_progress_display_style" value="bar" <?php checked(mobooking_get_setting_value($bf_settings, 'bf_progress_display_style', 'steps'), 'bar'); ?>>
+                                                    <input type="radio" name="bf_progress_display_style" value="bar" <?php checked(mobooking_get_setting_value($bf_settings, 'bf_progress_display_style', 'bar'), 'bar'); ?>>
                                                     <div class="card-content">
                                                         <span><?php esc_html_e('Progress Bar', 'mobooking'); ?></span>
                                                     </div>
                                                 </label>
                                                 <label>
-                                                    <input type="radio" name="bf_progress_display_style" value="none" <?php checked(mobooking_get_setting_value($bf_settings, 'bf_progress_display_style', 'steps'), 'none'); ?>>
+                                                    <input type="radio" name="bf_progress_display_style" value="none" <?php checked(mobooking_get_setting_value($bf_settings, 'bf_progress_display_style', 'bar'), 'none'); ?>>
                                                     <div class="card-content">
                                                         <span><?php esc_html_e('None', 'mobooking'); ?></span>
                                                     </div>
@@ -312,13 +306,8 @@ if (!empty($current_slug)) {
                                              <h2 id="preview-header-text"><?php echo esc_html(mobooking_get_setting_value($bf_settings, 'bf_header_text', 'Book Our Services Online')); ?></h2>
                                                 <p id="preview-description"><?php echo esc_html(mobooking_get_setting_value($bf_settings, 'bf_description')); ?></p>
                                             </div>
-                                            <div class="preview-progress-wrapper" style="padding: 1rem 0; min-height: 50px;">
-                                                <div class="preview-progress-steps" style="display: flex; justify-content: space-between; margin-bottom: 1rem;">
-                                                    <div class="mobooking-step-indicator active" style="position: relative;">1 <span class="step-label">Service</span></div>
-                                                    <div class="mobooking-step-indicator" style="position: relative;">2 <span class="step-label">Options</span></div>
-                                                    <div class="mobooking-step-indicator" style="position: relative;">3 <span class="step-label">Details</span></div>
-                                                </div>
-                                                <div class="preview-progress-bar" style="height: 8px; background-color: #e5e7eb; border-radius: 4px; overflow: hidden;">
+                                            <div class="preview-progress-wrapper" style="padding: 1rem 0; min-height: 20px;">
+                                                <div class="preview-progress-bar" style="height: 12px; background-color: #e5e7eb; border-radius: 6px; overflow: hidden;">
                                                     <div class="preview-progress-fill" style="width: 25%; height: 100%; background-color: var(--preview-primary, #1abc9c);"></div>
                                                 </div>
                                             </div>
@@ -664,16 +653,6 @@ if (!empty($current_slug)) {
     word-wrap: break-word;
 }
 
-.preview-progress-steps .mobooking-step-indicator .step-label {
-    display: block;
-    font-size: 0.7rem;
-    position: absolute;
-    bottom: -1.2rem;
-    left: 50%;
-    transform: translateX(-50%);
-    color: #6b7280;
-    white-space: nowrap;
-}
 
 .preview-progress-bar {
     width: 100%;
@@ -759,27 +738,14 @@ if (!empty($current_slug)) {
 document.addEventListener('DOMContentLoaded', function() {
     const progressStyleRadios = document.querySelectorAll('input[name="bf_progress_display_style"]');
     const previewWrapper = document.querySelector('.preview-progress-wrapper');
-    const previewSteps = document.querySelector('.preview-progress-steps');
-    const previewBar = document.querySelector('.preview-progress-bar');
 
     function updatePreview(style) {
-        if (!previewWrapper || !previewSteps || !previewBar) return;
+        if (!previewWrapper) return;
 
-        // Reset styles to default (steps view)
-        previewWrapper.style.display = 'block';
-        previewSteps.style.display = 'flex';
-        previewBar.style.height = '8px';
-        previewBar.style.marginTop = '1rem';
-
-        switch(style) {
-            case 'bar':
-                previewSteps.style.display = 'none';
-                previewBar.style.height = '12px';
-                previewBar.style.marginTop = '0.5rem';
-                break;
-            case 'none':
-                previewWrapper.style.display = 'none';
-                break;
+        if (style === 'none') {
+            previewWrapper.style.display = 'none';
+        } else {
+            previewWrapper.style.display = 'block';
         }
     }
 

--- a/templates/booking-form-public.php
+++ b/templates/booking-form-public.php
@@ -55,7 +55,6 @@ $form_config = [
     'form_enabled' => ($bf_settings['bf_form_enabled'] ?? '1') === '1',
     'theme_color' => $bf_settings['bf_theme_color'] ?? '#1abc9c',
     'header_text' => $bf_settings['bf_header_text'] ?? 'Book Our Services Online',
-    'progress_display_style' => $bf_settings['bf_progress_display_style'] ?? 'steps',
     'success_message' => $bf_settings['bf_success_message'] ?? 'Thank you for your booking! We will contact you soon to confirm the details.',
     'service_card_display' => $bf_settings['bf_service_card_display'] ?? 'image',
 ];
@@ -111,53 +110,9 @@ $script_data = [
     </div>
 
     <!-- Progress Bar -->
-    <?php
-    $progress_style = $bf_settings['bf_progress_display_style'] ?? 'steps';
-
-    // Backwards compatibility:
-    // If the new style setting has its default value ('steps') and the old 'show_progress_bar' setting was explicitly set to '0' (off),
-    // then we assume the user wanted it off and set the style to 'none'.
-    if ($progress_style === 'steps' && isset($bf_settings['bf_show_progress_bar']) && $bf_settings['bf_show_progress_bar'] === '0') {
-        $progress_style = 'none';
-    }
-    ?>
+    <?php $progress_style = $bf_settings['bf_progress_display_style'] ?? 'bar'; ?>
     <?php if ($progress_style !== 'none'): ?>
     <div class="mobooking-progress-container progress-style-<?php echo esc_attr($progress_style); ?>" id="mobooking-progress-container">
-        <?php if ($progress_style === 'steps'): ?>
-        <div class="mobooking-progress-steps">
-            <?php
-            $step_labels = [
-                1 => __('Area', 'mobooking'),
-                2 => __('Service', 'mobooking'),
-                3 => __('Options', 'mobooking'),
-                4 => __('Pets', 'mobooking'),
-                5 => __('Frequency', 'mobooking'),
-                6 => __('Date & Time', 'mobooking'),
-                7 => __('Details', 'mobooking'),
-                8 => __('Confirm', 'mobooking'),
-            ];
-            $total_steps = 8;
-            $visible_steps = [];
-
-            // Calculate visible steps based on enabled features
-            $step_counter = 1;
-            if ($form_config['enable_area_check']) $visible_steps[] = $step_counter++;
-            $visible_steps[] = $step_counter++; // Service selection (always enabled)
-            $visible_steps[] = $step_counter++; // Service options (always enabled)
-            $visible_steps[] = $step_counter++; // Pet Information - Always render indicator
-            $visible_steps[] = $step_counter++; // Service Frequency - Always render indicator
-            if ($form_config['enable_datetime_selection']) $visible_steps[] = $step_counter++;
-            if ($form_config['enable_property_access']) $visible_steps[] = $step_counter++;
-            $visible_steps[] = $step_counter++; // Success (always enabled)
-
-            foreach ($visible_steps as $i => $step):
-            ?>
-            <div class="mobooking-step-indicator <?php echo $i === 0 ? 'active' : ''; ?>" data-step="<?php echo $step; ?>" data-label="<?php echo esc_attr($step_labels[$step]); ?>">
-                <?php echo $step; ?>
-            </div>
-            <?php endforeach; ?>
-        </div>
-        <?php endif; ?>
         <div class="mobooking-progress-bar">
             <div class="mobooking-progress-fill" id="mobooking-progress-fill"></div>
         </div>


### PR DESCRIPTION
This commit refactors the booking form's progress indicator based on user feedback. The 'Steps with Labels' option has been removed to simplify the feature.

Key changes:

- **Simplified Setting:** The 'Progress Indicator Style' setting in the Form Appearance section now only offers 'Progress Bar' or 'None' as choices. The default has been set to 'Progress Bar'.
- **Removed Step View:** All HTML, CSS, and PHP logic related to the 'Steps with Labels' view has been removed from the public booking form and the admin preview.
- **Cleaned Up Code:** The settings logic, public template, and CSS files have been cleaned up to remove the now-unused code, resulting in a simpler and more maintainable implementation.