### PR TITLE
feat: Add field-level validation to booking form

### DIFF
--- a/assets/css/booking-form-validation.css
+++ b/assets/css/booking-form-validation.css
@@ -1,0 +1,45 @@
+/*
+ * Booking Form Validation Styles
+ */
+
+/* Style for input fields with an error */
+.mobooking-input.error,
+.mobooking-textarea.error,
+.mobooking-select.error {
+    border-color: #ef4444 !important; /* Red-500 from Tailwind palette */
+}
+
+.mobooking-input.error:focus,
+.mobooking-textarea.error:focus,
+.mobooking-select.error:focus {
+    box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.5);
+}
+
+
+/* Style for the error message */
+.mobooking-error-message {
+    color: #ef4444;
+    font-size: 0.875rem; /* 14px */
+    margin-top: 0.5rem; /* 8px */
+    display: block;
+}
+
+/* Adjustments for specific field types */
+.mobooking-form-group.error .mobooking-radio-group,
+.mobooking-form-group.error .mobooking-services-grid {
+    border: 1px solid #ef4444;
+    border-radius: 8px; /* Match existing border-radius if any */
+    padding: 1rem;
+}
+
+/* Add a general error class to highlight groups */
+.mobooking-form-group.error > .mobooking-label {
+    color: #ef4444;
+}
+
+/* Ensure the container for time slots can also show an error state */
+#mobooking-time-slots-container.error #mobooking-time-slots {
+    border: 1px solid #ef4444;
+    padding: 1rem;
+    border-radius: 8px;
+}

--- a/functions/theme-setup.php
+++ b/functions/theme-setup.php
@@ -98,6 +98,7 @@ $page_type_for_scripts = get_query_var('mobooking_page_type');
 if ( is_page_template('templates/booking-form-public.php') || $page_type_for_scripts === 'public_booking' || $page_type_for_scripts === 'embed_booking' ) {
     // Enqueue the new modern booking form CSS
     wp_enqueue_style( 'mobooking-booking-form-redesigned', MOBOOKING_THEME_URI . 'assets/css/booking-form-redesigned.css', array('mobooking-style'), MOBOOKING_VERSION );
+    wp_enqueue_style( 'mobooking-booking-form-validation', MOBOOKING_THEME_URI . 'assets/css/booking-form-validation.css', array('mobooking-booking-form-redesigned'), MOBOOKING_VERSION );
 
     wp_enqueue_style( 'flatpickr', 'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css', array(), '4.6.9' );
     wp_enqueue_script( 'flatpickr', 'https://cdn.jsdelivr.net/npm/flatpickr', array(), '4.6.9', true );

--- a/jules-scratch/verification/verify_validation.py
+++ b/jules-scratch/verification/verify_validation.py
@@ -1,0 +1,72 @@
+from playwright.sync_api import sync_playwright, Page, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # The README indicates the booking form is at /{slug}/booking/
+    # I'll try 'mobooking' as the slug. If this fails, I might need to find another slug.
+    page.goto("http://localhost/mobooking/booking/")
+
+    # --- Step 1: Area Check ---
+    # The form now starts at step 2 if area check is disabled.
+    # Let's check if step 1 is even visible.
+    step1 = page.locator("#mobooking-step-1")
+    if step1.is_visible():
+        # Click next without filling in the zip code
+        page.locator("#mobooking-step-1 button[type=submit]").click()
+        # Expect an error message
+        expect(page.locator("#mobooking-zip + .mobooking-error-message")).to_be_visible()
+        # Fill the zip to proceed
+        page.locator("#mobooking-zip").fill("10001")
+        page.locator("#mobooking-step-1 button[type=submit]").click()
+
+
+    # --- Step 2: Service Selection ---
+    # Wait for services to load
+    expect(page.locator(".mobooking-services-grid")).to_be_visible(timeout=10000)
+    # Click next without selecting a service
+    page.locator("#mobooking-step-2 .mobooking-btn-primary").click()
+    # Expect an error message
+    expect(page.locator("#mobooking-services-container + .mobooking-error-message")).to_be_visible()
+    # Select a service to proceed
+    page.locator(".mobooking-service-card").first.click()
+
+    # --- Step 7: Customer Details ---
+    # The form auto-advances, so we should be on step 3. Let's get to step 7.
+    page.locator("#mobooking-step-3 .mobooking-btn-primary").click()
+    # Handle conditional steps 4 and 5
+    if page.locator("#mobooking-step-4").is_visible():
+        page.locator("#mobooking-step-4 .mobooking-btn-primary").click()
+    if page.locator("#mobooking-step-5").is_visible():
+        page.locator("#mobooking-step-5 .mobooking-btn-primary").click()
+
+    # We should be on step 6 (Date/Time) now.
+    # Click next without selecting a date/time
+    page.locator("#mobooking-step-6 .mobooking-btn-primary").click()
+    expect(page.locator("#mobooking-service-date + .mobooking-error-message")).to_be_visible()
+    # Select a date to proceed
+    page.locator(".flatpickr-day:not(.flatpickr-disabled)").first.click()
+    # Wait for time slots
+    expect(page.locator(".mobooking-time-slot")).to_be_visible(timeout=10000)
+    page.locator(".mobooking-time-slot").first.click()
+    page.locator("#mobooking-step-6 .mobooking-btn-primary").click()
+
+    # Now we are on Step 7: Customer Details
+    # Click "Review Booking" without filling out the form
+    page.locator("#mobooking-step-7 .mobooking-btn-primary").click()
+
+    # Expect error messages for all required fields
+    expect(page.locator("#mobooking-customer-name + .mobooking-error-message")).to_be_visible()
+    expect(page.locator("#mobooking-customer-email + .mobooking-error-message")).to_be_visible()
+    expect(page.locator("#mobooking-customer-phone + .mobooking-error-message")).to_be_visible()
+    expect(page.locator("#mobooking-service-address + .mobooking-error-message")).to_be_visible()
+
+    # Take a screenshot to verify the new validation styling
+    page.screenshot(path="jules-scratch/verification/validation_errors.png")
+
+    browser.close()
+
+with sync_playwright() as p:
+    run(p)


### PR DESCRIPTION
This commit refactors the booking form validation to display errors directly on the individual form fields instead of in a single feedback container per step.

- A new CSS file, `booking-form-validation.css`, has been created and enqueued to style the error states on input fields (red border) and the error messages.
- The JavaScript in `booking-form-public.js` has been updated to include new helper functions (`showFieldError`, `clearFieldErrors`) that manage the display of these field-specific errors.
- The `validateStep` function has been refactored to use this new mechanism for all validation checks, ensuring that error messages are translatable and appear next to the corresponding field.