### PR TITLE
feat: Clear validation errors on input

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -468,6 +468,20 @@ jQuery(document).ready(function ($) {
     }
   }
 
+  function clearFieldError(field) {
+    const $field = $(field);
+    const $group = $field.closest(".mobooking-form-group.error");
+
+    $field.removeClass("error");
+    $field.siblings(".mobooking-error-message").remove();
+    $field.next(".mobooking-error-message").remove(); // Ensure message after field is removed
+
+    if ($group.length) {
+      $group.removeClass("error");
+      $group.find(".mobooking-error-message").remove();
+    }
+  }
+
   function clearFieldErrors(stepContainer) {
     $(stepContainer).find(".error").removeClass("error");
     $(stepContainer).find(".mobooking-error-message").remove();
@@ -1168,6 +1182,7 @@ jQuery(document).ready(function ($) {
         collapseTimeSlots(true);
         els.timeSlots.empty();
         if (state.date) loadTimeSlots(dateStr);
+        clearFieldError(els.dateInput);
       },
       onReady: function (selectedDates, dateStr, instance) {
         $(instance.calendarContainer).addClass("mobooking-flatpickr");
@@ -1561,4 +1576,33 @@ jQuery(document).ready(function ($) {
   });
 
   // Property access radios active styling is handled in the STEP 7 section
+
+  // ==========================================
+  // LIVE VALIDATION
+  // ==========================================
+  // Clear validation errors on user input for simple fields
+  $(document).on(
+    "input change",
+    "#mobooking-zip, #mobooking-pet-details, #mobooking-customer-name, #mobooking-customer-email, #mobooking-customer-phone, #mobooking-service-address",
+    function () {
+      clearFieldError($(this));
+    }
+  );
+
+  // Clear validation on complex components
+  $(document).on("change", ".mobooking-option-input", function () {
+    clearFieldError($(this));
+  });
+
+  els.servicesContainer.on(
+    "change",
+    'input[name="mobooking-selected-service"]',
+    function () {
+      clearFieldError(els.servicesContainer);
+    }
+  );
+
+  els.timeSlots.on("click", ".mobooking-time-slot", function () {
+    clearFieldError(els.timeSlotsWrap);
+  });
 });

--- a/jules-scratch/verification/verify_validation.py
+++ b/jules-scratch/verification/verify_validation.py
@@ -58,13 +58,34 @@ def run(playwright):
     page.locator("#mobooking-step-7 .mobooking-btn-primary").click()
 
     # Expect error messages for all required fields
-    expect(page.locator("#mobooking-customer-name + .mobooking-error-message")).to_be_visible()
-    expect(page.locator("#mobooking-customer-email + .mobooking-error-message")).to_be_visible()
-    expect(page.locator("#mobooking-customer-phone + .mobooking-error-message")).to_be_visible()
-    expect(page.locator("#mobooking-service-address + .mobooking-error-message")).to_be_visible()
+    name_error = page.locator("#mobooking-customer-name ~ .mobooking-error-message")
+    email_error = page.locator("#mobooking-customer-email ~ .mobooking-error-message")
+    phone_error = page.locator("#mobooking-customer-phone ~ .mobooking-error-message")
+    address_error = page.locator("#mobooking-service-address ~ .mobooking-error-message")
+
+    expect(name_error).to_be_visible()
+    expect(email_error).to_be_visible()
+    expect(phone_error).to_be_visible()
+    expect(address_error).to_be_visible()
 
     # Take a screenshot to verify the new validation styling
     page.screenshot(path="jules-scratch/verification/validation_errors.png")
+
+    # --- Test that errors are cleared on input ---
+    page.locator("#mobooking-customer-name").fill("John Doe")
+    expect(name_error).not_to_be_visible()
+
+    page.locator("#mobooking-customer-email").fill("john.doe@example.com")
+    expect(email_error).not_to_be_visible()
+
+    page.locator("#mobooking-customer-phone").fill("1234567890")
+    expect(phone_error).not_to_be_visible()
+
+    page.locator("#mobooking-service-address").fill("123 Main St")
+    expect(address_error).not_to_be_visible()
+
+    # Take a final screenshot to show the cleared errors
+    page.screenshot(path="jules-scratch/verification/validation_cleared.png")
 
     browser.close()
 


### PR DESCRIPTION
This commit enhances the field-level validation by adding live feedback. Now, when a user interacts with a field that has a validation error, the error class and message are immediately removed.

- A new `clearFieldError` function has been added to `booking-form-public.js` to remove errors from a specific field.
- Event listeners for `input` and `change` events have been added to all validated fields. These listeners trigger the `clearFieldError` function, providing instant feedback to the user as they correct their input.