### PR TITLE
fix: Skip validation for toggle switch options

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -337,14 +337,17 @@ jQuery(document).ready(function ($) {
 
           const firstInput = requiredInputs.first();
           const type = firstInput.data("type");
+
+          if (type === "toggle") {
+            return; // Skip validation for toggle types as per user request
+          }
+
           const name = firstInput.data("name") || "Option";
           let isGroupValid = true;
 
-          if (type === "toggle" || type === "checkbox") {
+          if (type === "checkbox") {
             if (
-              $group.find(
-                "input[type='checkbox']:checked, input[type='toggle']:checked"
-              ).length === 0
+              $group.find("input[type='checkbox']:checked").length === 0
             ) {
               isGroupValid = false;
             }


### PR DESCRIPTION
This commit removes the validation requirement for service options of the 'toggle' type in the booking form, as requested by the user.

- The validation logic in `assets/js/booking-form-public.js` has been updated to specifically ignore required fields that are of the `toggle` type.