### PR TITLE
fix(js): Define missing showFeedback function

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -490,6 +490,11 @@ jQuery(document).ready(function ($) {
     $(stepContainer).find(".mobooking-error-message").remove();
   }
 
+  function showFeedback(element, type, message) {
+    element.removeClass("info success error").addClass(type);
+    element.text(message).show();
+  }
+
   // Expose for template buttons
   window.moBookingNextStep = nextStep;
   window.moBookingPreviousStep = prevStep;


### PR DESCRIPTION
The `showFeedback` function was being called in `assets/js/booking-form-public.js` to display feedback messages for the zipcode check, but it was not defined anywhere in the scope.

This caused a `ReferenceError` which prevented the feedback from being displayed.

This change adds the definition of the `showFeedback` function to resolve the error. The function handles showing info, success, and error messages to the user.