### PR TITLE
Fix: Define showFeedback function in booking form

### DIFF
--- a/assets/js/booking-form-public.js
+++ b/assets/js/booking-form-public.js
@@ -490,6 +490,21 @@ jQuery(document).ready(function ($) {
     $(stepContainer).find(".mobooking-error-message").remove();
   }
 
+  function showFeedback(element, type, message) {
+    if (!element || !element.length) return;
+    const typeToClass = {
+      success: "mobooking-feedback-success",
+      error: "mobooking-feedback-error",
+      info: "mobooking-feedback-info",
+    };
+    const cssClass = typeToClass[type] || typeToClass.info;
+    element
+      .removeClass(Object.values(typeToClass).join(" "))
+      .addClass(cssClass)
+      .html(message)
+      .show();
+  }
+
   // Expose for template buttons
   window.moBookingNextStep = nextStep;
   window.moBookingPreviousStep = prevStep;

--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
  */
 
 if ( ! defined( 'MOBOOKING_VERSION' ) ) {
-    define( 'MOBOOKING_VERSION', '0.1.19' );
+    define( 'MOBOOKING_VERSION', '0.1.20' );
 }
 if ( ! defined( 'MOBOOKING_DB_VERSION' ) ) {
     define( 'MOBOOKING_DB_VERSION', '2.3' );

--- a/jules-scratch/verification/verify_feedback_message.py
+++ b/jules-scratch/verification/verify_feedback_message.py
@@ -1,0 +1,43 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # The base URL will be provided by the testing environment, so I can use a relative path.
+    page.goto("/booking/test-company-inc/", wait_until="networkidle")
+
+    # Wait for the zip code input to be visible
+    zip_input = page.locator("#mobooking-zip")
+    expect(zip_input).to_be_visible()
+
+    # Click the submit button without entering a zip code to trigger an error
+    page.locator("#mobooking-area-check-form button[type=submit]").click()
+
+    # Check for the error message
+    error_feedback = page.locator("#mobooking-location-feedback")
+    expect(error_feedback).to_have_class(
+        "mobooking-feedback-error"
+    )
+    expect(error_feedback).to_be_visible()
+
+    # Now enter a valid zip code to trigger a success message
+    # From the test files, it seems like the zip code check is mocked and will succeed.
+    zip_input.fill("12345")
+
+    # The success message should appear after a debounce
+    page.wait_for_timeout(1000)
+
+    success_feedback = page.locator("#mobooking-location-feedback")
+    expect(success_feedback).to_have_class(
+        "mobooking-feedback-success"
+    )
+    expect(success_feedback).to_be_visible()
+
+    page.screenshot(path="jules-scratch/verification/verification.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
The public booking form was throwing a `ReferenceError` because the `showFeedback` function was called but not defined in `booking-form-public.js`.

This change:
1.  Defines the `showFeedback` function within `assets/js/booking-form-public.js` to display feedback messages (success, error, info) to the user.
2.  Increments the `MOBOOKING_VERSION` constant in `functions.php` to ensure the updated script is served to browsers.