### PR TITLE
Fix: Resolve registration error caused by duplicate password field ID

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -180,10 +180,10 @@ jQuery(document).ready(function ($) {
         );
         isValid = false;
       }
-      const password = $("#NORDBOOKING-user-pass").val();
+      const password = $("#NORDBOOKING-user-pass-register").val();
       if (password.length < 8) {
         showFieldError(
-          $("#NORDBOOKING-user-pass"),
+          $("#NORDBOOKING-user-pass-register"),
           "Password must be at least 8 characters."
         );
         isValid = false;

--- a/page-register.php
+++ b/page-register.php
@@ -104,8 +104,8 @@ if ( isset( $_GET['invitation_token'] ) ) {
                             <input type="email" name="email" id="NORDBOOKING-user-email" class="input" value="<?php echo esc_attr( $worker_email ); ?>" required <?php if ( $is_invitation && !empty($worker_email) ) echo 'readonly'; ?> />
                         </p>
                         <p class="register-password">
-                            <label for="NORDBOOKING-user-pass"><?php esc_html_e( 'Password (min. 8 characters)', 'NORDBOOKING' ); ?></label>
-                            <input type="password" name="password" id="NORDBOOKING-user-pass" class="input" value="" required />
+                            <label for="NORDBOOKING-user-pass-register"><?php esc_html_e( 'Password (min. 8 characters)', 'NORDBOOKING' ); ?></label>
+                            <input type="password" name="password" id="NORDBOOKING-user-pass-register" class="input" value="" required />
                         </p>
                         <p class="register-password-confirm">
                             <label for="NORDBOOKING-user-pass-confirm"><?php esc_html_e( 'Confirm Password', 'NORDBOOKING' ); ?></label>


### PR DESCRIPTION
The registration form was showing a login error ("Unknown email address") because the password field on the registration page had the same ID as the password field on the login page. This caused the wrong javascript validation to be triggered.

This commit fixes the issue by giving the password field on the registration page a unique ID and updating the corresponding javascript.