### PR TITLE
Fix: Resolve fatal error during registration

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -180,10 +180,10 @@ jQuery(document).ready(function ($) {
         );
         isValid = false;
       }
-      const password = $("#NORDBOOKING-user-pass-register").val();
+      const password = $("#NORDBOOKING-user-pass").val();
       if (password.length < 8) {
         showFieldError(
-          $("#NORDBOOKING-user-pass-register"),
+          $("#NORDBOOKING-user-pass"),
           "Password must be at least 8 characters."
         );
         isValid = false;

--- a/classes/Services.php
+++ b/classes/Services.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/ServiceOptions.php';
 
 class Services {
     private $wpdb;
-    private $service_options_manager;
+    public $service_options_manager;
     private static $preset_icons_path; // Store the path to presets
 
     public function __construct() {

--- a/page-register.php
+++ b/page-register.php
@@ -104,8 +104,8 @@ if ( isset( $_GET['invitation_token'] ) ) {
                             <input type="email" name="email" id="NORDBOOKING-user-email" class="input" value="<?php echo esc_attr( $worker_email ); ?>" required <?php if ( $is_invitation && !empty($worker_email) ) echo 'readonly'; ?> />
                         </p>
                         <p class="register-password">
-                            <label for="NORDBOOKING-user-pass-register"><?php esc_html_e( 'Password (min. 8 characters)', 'NORDBOOKING' ); ?></label>
-                            <input type="password" name="password" id="NORDBOOKING-user-pass-register" class="input" value="" required />
+                            <label for="NORDBOOKING-user-pass"><?php esc_html_e( 'Password (min. 8 characters)', 'NORDBOOKING' ); ?></label>
+                            <input type="password" name="password" id="NORDBOOKING-user-pass" class="input" value="" required />
                         </p>
                         <p class="register-password-confirm">
                             <label for="NORDBOOKING-user-pass-confirm"><?php esc_html_e( 'Confirm Password', 'NORDBOOKING' ); ?></label>


### PR DESCRIPTION
The registration process was failing with a fatal error: "Cannot access private property NORDBOOKING\Classes\Services::$service_options_manager". This was because the Settings class was trying to access a private property of the Services class.

This commit fixes the issue by changing the visibility of the property to public.