### PR TITLE
feat: Add interactive calendar page to dashboard

### DIFF
--- a/functions/routing.php
+++ b/functions/routing.php
@@ -193,9 +193,9 @@ function nordbooking_enqueue_dashboard_scripts($current_page_slug = '') {
 
     // Specific to Calendar page
     if ($current_page_slug === 'calendar') {
-        wp_enqueue_style('fullcalendar', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.css', array(), '6.1.11');
-        wp_enqueue_script('fullcalendar', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.js', array('jquery'), '6.1.11', true);
-        wp_enqueue_script('nordbooking-dashboard-calendar', NORDBOOKING_THEME_URI . 'assets/js/dashboard-calendar.js', array('jquery', 'fullcalendar', 'nordbooking-dialog'), NORDBOOKING_VERSION, true);
+        wp_enqueue_style('nordbooking-fullcalendar', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.css', array(), '6.1.11');
+        wp_enqueue_script('nordbooking-fullcalendar', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.js', array('jquery'), '6.1.11', true);
+        wp_enqueue_script('nordbooking-dashboard-calendar', NORDBOOKING_THEME_URI . 'assets/js/dashboard-calendar.js', array('jquery', 'nordbooking-fullcalendar', 'nordbooking-dialog'), NORDBOOKING_VERSION, true);
 
         wp_localize_script('nordbooking-dashboard-calendar', 'nordbooking_calendar_params', [
             'ajax_url' => admin_url('admin-ajax.php'),


### PR DESCRIPTION
This commit introduces a new 'Calendar' page to the dashboard, providing users with a full-page interactive calendar to view and manage their bookings.

Key changes:
- Created a new `dashboard/page-calendar.php` template for the calendar view.
- Added a 'Calendar' link to the dashboard sidebar in `dashboard/sidebar.php` and a corresponding icon in `functions/utilities.php`.
- Registered the new 'calendar' route in `classes/Routes/BookingFormRouter.php`.
- Integrated FullCalendar.js to render the interactive calendar.
- Created `assets/js/dashboard-calendar.js` to handle calendar initialization, event fetching, and user interactions.
- Enabled the existing `nordbooking_get_all_bookings_for_calendar` AJAX endpoint in `functions/ajax.php` to provide booking data to the calendar.
- Implemented an `eventClick` feature that displays a dialog with booking details.

Fixes script loading issue for FullCalendar by using prefixed handles to prevent conflicts.