### PR TITLE
feat: Add interactive calendar page to dashboard

### DIFF
--- a/functions/routing.php
+++ b/functions/routing.php
@@ -191,23 +191,6 @@ function nordbooking_enqueue_dashboard_scripts($current_page_slug = '') {
         wp_localize_script('nordbooking-dashboard-bookings', 'nordbooking_bookings_params', $bookings_params);
     }
 
-    // Specific to Calendar page
-    if ($current_page_slug === 'calendar') {
-        wp_enqueue_style('nordbooking-fullcalendar', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.css', array(), '6.1.11');
-        wp_enqueue_script('nordbooking-fullcalendar', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.js', array('jquery'), '6.1.11', true);
-        wp_enqueue_script('nordbooking-dashboard-calendar', NORDBOOKING_THEME_URI . 'assets/js/dashboard-calendar.js', array('jquery', 'nordbooking-fullcalendar', 'nordbooking-dialog'), NORDBOOKING_VERSION, true);
-
-        wp_localize_script('nordbooking-dashboard-calendar', 'nordbooking_calendar_params', [
-            'ajax_url' => admin_url('admin-ajax.php'),
-            'nonce' => wp_create_nonce('nordbooking_calendar_nonce'),
-						'i18n' => [
-                'loading_events' => __('Loading events...', 'NORDBOOKING'),
-                'error_loading_events' => __('Error loading events.', 'NORDBOOKING'),
-								'booking_details' => __('Booking Details', 'NORDBOOKING'),
-            ]
-        ]);
-    }
-
     // Specific to Discounts page
     if ($current_page_slug === 'discounts') {
         wp_enqueue_style('nordbooking-dashboard-discounts', NORDBOOKING_THEME_URI . 'assets/css/dashboard-discounts.css', array(), NORDBOOKING_VERSION);

--- a/functions/theme-setup.php
+++ b/functions/theme-setup.php
@@ -501,6 +501,21 @@ if ( is_page_template('templates/booking-form-public.php') || $page_type_for_scr
             }
         }
 
+        if ($current_page_slug === 'calendar') {
+            wp_enqueue_style('nordbooking-fullcalendar', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.css', array(), '6.1.11');
+            wp_enqueue_script('nordbooking-fullcalendar', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.js', array('jquery'), '6.1.11', true);
+            wp_enqueue_script('nordbooking-dashboard-calendar', NORDBOOKING_THEME_URI . 'assets/js/dashboard-calendar.js', array('jquery', 'nordbooking-fullcalendar', 'nordbooking-dialog'), NORDBOOKING_VERSION, true);
+
+            wp_localize_script('nordbooking-dashboard-calendar', 'nordbooking_calendar_params', [
+                'ajax_url' => admin_url('admin-ajax.php'),
+                'nonce' => wp_create_nonce('nordbooking_calendar_nonce'),
+                'i18n' => [
+                    'loading_events' => __('Loading events...', 'NORDBOOKING'),
+                    'error_loading_events' => __('Error loading events.', 'NORDBOOKING'),
+                    'booking_details' => __('Booking Details', 'NORDBOOKING'),
+                ]
+            ]);
+        }
     }
     flush_rewrite_rules();
 }


### PR DESCRIPTION
This commit introduces a new 'Calendar' page to the dashboard, providing users with a full-page interactive calendar to view and manage their bookings.

Key changes:
- Created a new `dashboard/page-calendar.php` template for the calendar view.
- Added a 'Calendar' link to the dashboard sidebar in `dashboard/sidebar.php` and a corresponding icon in `functions/utilities.php`.
- Registered the new 'calendar' route in `classes/Routes/BookingFormRouter.php`.
- Integrated FullCalendar.js to render the interactive calendar.
- Created `assets/js/dashboard-calendar.js` to handle calendar initialization, event fetching, and user interactions.
- Enabled the existing `nordbooking_get_all_bookings_for_calendar` AJAX endpoint in `functions/ajax.php` to provide booking data to the calendar.
- Implemented an `eventClick` feature that displays a dialog with booking details.

Fix: Moves script enqueueing logic to the `wp_enqueue_scripts` action hook in `functions/theme-setup.php` to ensure correct loading order and prevent "FullCalendar is not defined" errors.