### PR TITLE
feat: Replace FullCalendar with Schedule-X

### DIFF
--- a/assets/js/dashboard-calendar.js
+++ b/assets/js/dashboard-calendar.js
@@ -1,106 +1,100 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const calendarEl = document.getElementById('booking-calendar');
+    const calendarEl = document.getElementById('schedule-x-calendar');
     if (!calendarEl) {
         return;
     }
 
-    const calendar = new FullCalendar.Calendar(calendarEl, {
-        initialView: 'dayGridMonth',
-        headerToolbar: {
-            left: 'prev,next today',
-            center: 'title',
-            right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek'
-        },
-        events: function(fetchInfo, successCallback, failureCallback) {
-            const params = new URLSearchParams();
-            params.append('action', 'nordbooking_get_all_bookings_for_calendar');
-            params.append('nonce', nordbooking_calendar_params.nonce);
-            params.append('start', fetchInfo.startStr);
-            params.append('end', fetchInfo.endStr);
+    const params = new URLSearchParams();
+    params.append('action', 'nordbooking_get_all_bookings_for_calendar');
+    params.append('nonce', nordbooking_calendar_params.nonce);
 
-            fetch(nordbooking_calendar_params.ajax_url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                body: params
-            })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error('Network response was not ok');
-                }
-                return response.json();
-            })
-            .then(data => {
-                // Handle WordPress's standard { success: true, data: [...] } response.
-                if (data.success && Array.isArray(data.data)) {
-                    successCallback(data.data);
-                } else {
-                    // If the format is wrong, or if success is false.
-                    console.error('Invalid event data received from server:', data);
-                    failureCallback(new Error('Invalid event data format.'));
-                }
-            })
-            .catch(error => {
-                console.error('Error fetching events:', error);
-                failureCallback(error);
-                alert(nordbooking_calendar_params.i18n.error_loading_events);
-            });
+    fetch(nordbooking_calendar_params.ajax_url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
         },
-        loading: function(isLoading) {
-            if (isLoading) {
-                // You can add a loading indicator here if you want
-                console.log(nordbooking_calendar_params.i18n.loading_events);
-            } else {
-                // and hide it here
-            }
-        },
-        eventClick: function(info) {
-            info.jsEvent.preventDefault(); // don't let the browser navigate
-
-            const booking = info.event.extendedProps;
-            let detailsHtml = `
-                <p><strong>${nordbooking_calendar_params.i18n.booking_details}</strong></p>
-                <ul>
-                    <li><strong>Customer:</strong> ${booking.customer_name}</li>
-                    <li><strong>Email:</strong> ${booking.customer_email}</li>
-                    <li><strong>Phone:</strong> ${booking.customer_phone}</li>
-                    <li><strong>Service:</strong> ${booking.service_name}</li>
-                    <li><strong>Date:</strong> ${new Date(booking.booking_date).toLocaleDateString()}</li>
-                    <li><strong>Time:</strong> ${booking.booking_time}</li>
-                    <li><strong>Status:</strong> <span class="status-badge status-${booking.status}">${booking.status}</span></li>
-                    <li><strong>Price:</strong> ${booking.total_price} ${booking.currency}</li>
-                </ul>
-            `;
-
-            if (window.NordbookingDialog) {
-                new window.NordbookingDialog({
-                    title: `Booking #${booking.booking_id}`,
-                    content: detailsHtml,
-                    buttons: [
-                        {
-                            label: 'Close',
-                            class: 'secondary',
-                            onClick: (dialog) => {
-                                dialog.close();
-                            }
-                        },
-                        {
-                            label: 'View Details',
-                            class: 'primary',
-                            onClick: () => {
-                                window.location.href = info.event.url;
-                            }
-                        }
-                    ]
-                }).show();
-            } else {
-                // Fallback if the dialog is not available
-                alert(detailsHtml.replace(/<[^>]+>/g, '\n'));
-                window.open(info.event.url, "_blank");
-            }
+        body: params
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
         }
-    });
+        return response.json();
+    })
+    .then(data => {
+        if (data.success && Array.isArray(data.data)) {
+            const events = data.data.map(booking => {
+                return {
+                    id: booking.id,
+                    title: booking.title,
+                    start: booking.start,
+                    end: booking.end,
+                    extendedProps: booking.extendedProps
+                };
+            });
 
-    calendar.render();
+            const calendar = window.SXCalendar.createCalendar({
+                views: [
+                    window.SXCalendar.createViewMonthGrid(),
+                    window.SXCalendar.createViewWeek(),
+                    window.SXCalendar.createViewDay()
+                ],
+                events: events,
+                plugins: [
+                    window.SXDragAndDrop.createDragAndDropPlugin()
+                ],
+                eventClick: function(info) {
+                    const booking = info.event.extendedProps;
+                    let detailsHtml = `
+                        <p><strong>${nordbooking_calendar_params.i18n.booking_details}</strong></p>
+                        <ul>
+                            <li><strong>Customer:</strong> ${booking.customer_name}</li>
+                            <li><strong>Email:</strong> ${booking.customer_email}</li>
+                            <li><strong>Phone:</strong> ${booking.customer_phone}</li>
+                            <li><strong>Service:</strong> ${booking.service_name}</li>
+                            <li><strong>Date:</strong> ${new Date(booking.booking_date).toLocaleDateString()}</li>
+                            <li><strong>Time:</strong> ${booking.booking_time}</li>
+                            <li><strong>Status:</strong> <span class="status-badge status-${booking.status}">${booking.status}</span></li>
+                            <li><strong>Price:</strong> ${booking.total_price} ${booking.currency}</li>
+                        </ul>
+                    `;
+
+                    if (window.NordbookingDialog) {
+                        new window.NordbookingDialog({
+                            title: `Booking #${booking.booking_id}`,
+                            content: detailsHtml,
+                            buttons: [
+                                {
+                                    label: 'Close',
+                                    class: 'secondary',
+                                    onClick: (dialog) => {
+                                        dialog.close();
+                                    }
+                                },
+                                {
+                                    label: 'View Details',
+                                    class: 'primary',
+                                    onClick: () => {
+                                        window.location.href = booking.url;
+                                    }
+                                }
+                            ]
+                        }).show();
+                    } else {
+                        alert(detailsHtml.replace(/<[^>]+>/g, '\n'));
+                        window.open(booking.url, "_blank");
+                    }
+                }
+            });
+
+            calendar.render(calendarEl);
+        } else {
+            console.error('Invalid event data received from server:', data);
+            alert(nordbooking_calendar_params.i18n.error_loading_events);
+        }
+    })
+    .catch(error => {
+        console.error('Error fetching events:', error);
+        alert(nordbooking_calendar_params.i18n.error_loading_events);
+    });
 });

--- a/dashboard/page-calendar.php
+++ b/dashboard/page-calendar.php
@@ -11,17 +11,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <div class="nordbooking-dashboard-page-content">
-    <h1 class="nordbooking-dashboard-page-title"><?php esc_html_e( 'Calendar', 'NORDBOOKING' ); ?></h1>
-    <p class="nordbooking-dashboard-page-description"><?php esc_html_e( 'View and manage your bookings in a calendar format.', 'NORDBOOKING' ); ?></p>
+    <div class="nordbooking-page-header">
+        <h1 class="nordbooking-dashboard-page-title"><?php esc_html_e( 'Calendar', 'NORDBOOKING' ); ?></h1>
+        <p class="nordbooking-dashboard-page-description"><?php esc_html_e( 'View and manage your bookings in a calendar format.', 'NORDBOOKING' ); ?></p>
+    </div>
 
     <div class="nordbooking-card">
-        <div id="booking-calendar"></div>
+        <div id="schedule-x-calendar"></div>
     </div>
 </div>
 
 <style>
-    #booking-calendar {
-        /* max-width is removed to allow full width */
-        margin: 40px 0; /* Adjust margin for full-width layout */
+    #schedule-x-calendar {
+        max-height: 700px;
+        margin: 40px 0;
     }
 </style>

--- a/functions/theme-setup.php
+++ b/functions/theme-setup.php
@@ -342,16 +342,18 @@ if ( is_page_template('templates/booking-form-public.php') || $page_type_for_scr
 
         // Enqueue calendar scripts only on the calendar page.
         if ($current_page_slug === 'calendar') {
-            // The main.min.css is correct for styling.
-            wp_enqueue_style('fullcalendar-css', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.css', array(), '6.1.11');
-            // Enqueue the new custom theme for the calendar.
-            wp_enqueue_style('nordbooking-calendar-theme', NORDBOOKING_THEME_URI . 'assets/css/dashboard-calendar-theme.css', array('fullcalendar-css'), NORDBOOKING_VERSION);
+            wp_enqueue_style('schedule-x-css', 'https://cdn.jsdelivr.net/npm/@schedule-x/theme-default@2.2.0/dist/index.css', array(), '2.2.0');
 
-            // Use the correct global bundle for FullCalendar from the CDN, which creates the `FullCalendar` global object.
-            wp_enqueue_script('fullcalendar', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js', array(), '6.1.11', true);
+            wp_enqueue_script('preact', 'https://cdn.jsdelivr.net/npm/preact@10.23.2/dist/preact.min.js', array(), '10.23.2', true);
+            wp_enqueue_script('preact-hooks', 'https://cdn.jsdelivr.net/npm/preact@10.23.2/hooks/dist/hooks.umd.js', array('preact'), '10.23.2', true);
+            wp_enqueue_script('preact-signals-core', 'https://cdn.jsdelivr.net/npm/@preact/signals-core@1.8.0/dist/signals-core.min.js', array(), '1.8.0', true);
+            wp_enqueue_script('preact-signals', 'https://cdn.jsdelivr.net/npm/@preact/signals@1.3.0/dist/signals.min.js', array('preact-signals-core'), '1.3.0', true);
+            wp_enqueue_script('preact-jsx-runtime', 'https://cdn.jsdelivr.net/npm/preact@10.23.2/jsx-runtime/dist/jsxRuntime.umd.js', array('preact'), '10.23.2', true);
+            wp_enqueue_script('preact-compat', 'https://cdn.jsdelivr.net/npm/preact@10.23.2/compat/dist/compat.umd.js', array('preact'), '10.23.2', true);
+            wp_enqueue_script('schedule-x-calendar', 'https://cdn.jsdelivr.net/npm/@schedule-x/calendar@2.2.0/dist/core.umd.js', array('preact', 'preact-hooks', 'preact-signals'), '2.2.0', true);
+            wp_enqueue_script('schedule-x-drag-and-drop', 'https://cdn.jsdelivr.net/npm/@schedule-x/drag-and-drop@2.2.0/dist/core.umd.js', array('schedule-x-calendar'), '2.2.0', true);
 
-            // This script depends on 'fullcalendar' which is now correctly loaded.
-            wp_enqueue_script('nordbooking-dashboard-calendar', NORDBOOKING_THEME_URI . 'assets/js/dashboard-calendar.js', array('jquery', 'fullcalendar', 'nordbooking-dialog'), NORDBOOKING_VERSION, true);
+            wp_enqueue_script('nordbooking-dashboard-calendar', NORDBOOKING_THEME_URI . 'assets/js/dashboard-calendar.js', array('jquery', 'schedule-x-calendar', 'nordbooking-dialog'), NORDBOOKING_VERSION, true);
             wp_localize_script('nordbooking-dashboard-calendar', 'nordbooking_calendar_params', [
                 'ajax_url' => admin_url('admin-ajax.php'),
                 'nonce' => wp_create_nonce('nordbooking_calendar_nonce'),


### PR DESCRIPTION
Replaced the FullCalendar implementation with Schedule-X on the calendar page.

- Enqueued Schedule-X scripts and styles and dequeued FullCalendar.
- Updated the calendar page to use the new Schedule-X element and styles.
- Added the nordbooking-page-header to the calendar page.
- Set the max-height of the calendar to 700px.