### PR TITLE
feat: Add service performance chart to overview page

### DIFF
--- a/assets/js/dashboard-overview-enhanced.js
+++ b/assets/js/dashboard-overview-enhanced.js
@@ -100,10 +100,62 @@
       });
     },
 
+    initServicePerformanceChart() {
+      const ctx = document.getElementById("service-performance-chart");
+      if (!ctx) return;
+
+      $.ajax({
+          url: nordbooking_overview_params.ajax_url,
+          type: 'POST',
+          data: {
+              action: 'nordbooking_get_service_performance',
+              nonce: nordbooking_overview_params.nonce,
+          },
+          success: (response) => {
+              if (response.success) {
+                  this.charts.servicePerformance = new Chart(ctx, {
+                      type: 'bar',
+                      data: {
+                          labels: response.data.labels,
+                          datasets: [{
+                              label: 'Bookings',
+                              data: response.data.data,
+                              backgroundColor: 'hsl(221.2 83.2% 53.3%)',
+                              borderColor: 'hsl(221.2 83.2% 53.3%)',
+                              borderWidth: 1
+                          }]
+                      },
+                      options: {
+                          responsive: true,
+                          maintainAspectRatio: false,
+                          scales: {
+                              y: {
+                                  beginAtZero: true,
+                                  ticks: {
+                                      stepSize: 1
+                                  }
+                              }
+                          },
+                          plugins: {
+                              legend: {
+                                  display: false
+                              }
+                          }
+                      }
+                  });
+              }
+          },
+          error: (error) => {
+              console.error("Error fetching service performance data:", error);
+          }
+      });
+    },
+
     // Initialize Chart.js charts
     initializeCharts() {
       this.initRevenueChart();
       this.initPerformanceChart();
+      this.initServicePerformanceChart();
     },
 
     // Initialize revenue chart

--- a/classes/ServicePerformance.php
+++ b/classes/ServicePerformance.php
@@ -1,0 +1,52 @@
+<?php
+namespace NORDBOOKING\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+class ServicePerformance {
+    public function __construct() {
+        add_action('wp_ajax_nordbooking_get_service_performance', [$this, 'get_service_performance_data']);
+    }
+
+    public function get_service_performance_data() {
+        check_ajax_referer('nordbooking_ajax_nonce', 'nonce');
+
+        global $wpdb;
+        $bookings_table = Database::get_table_name('bookings');
+        $services_table = Database::get_table_name('services');
+
+        $current_user_id = get_current_user_id();
+        $data_user_id = $current_user_id;
+
+        if (class_exists('NORDBOOKING\Classes\Auth') && Auth::is_user_worker($current_user_id)) {
+            $owner_id = Auth::get_business_owner_id_for_worker($current_user_id);
+            if ($owner_id) {
+                $data_user_id = $owner_id;
+            }
+        }
+
+        $results = $wpdb->get_results($wpdb->prepare(
+            "SELECT s.name, COUNT(b.booking_id) as booking_count
+            FROM {$bookings_table} b
+            JOIN {$services_table} s ON b.service_id = s.id
+            WHERE b.user_id = %d
+            GROUP BY s.name
+            ORDER BY booking_count DESC
+            LIMIT 10",
+            $data_user_id
+        ), ARRAY_A);
+
+        $labels = [];
+        $data = [];
+
+        foreach ($results as $row) {
+            $labels[] = $row['name'];
+            $data[] = (int)$row['booking_count'];
+        }
+
+        wp_send_json_success([
+            'labels' => $labels,
+            'data' => $data,
+        ]);
+    }
+}

--- a/dashboard/page-overview.php
+++ b/dashboard/page-overview.php
@@ -397,6 +397,19 @@ $currency_symbol = get_option('nordbooking_currency_symbol', '$');
 
         <!-- Main Content Grid -->
         <div class="content-grid">
+            <!-- Service Performance Chart -->
+            <div class="nordbooking-card">
+                <div class="nordbooking-card-header">
+                    <div class="nordbooking-card-title-group">
+                        <span class="nordbooking-card-icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-bar-chart-3"><path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg></span>
+                        <h3 class="nordbooking-card-title"><?php esc_html_e('Services Performance', 'NORDBOOKING'); ?></h3>
+                    </div>
+                </div>
+                <div class="nordbooking-card-content">
+                    <canvas id="service-performance-chart" style="height: 300px;"></canvas>
+                </div>
+            </div>
+
             <!-- Recent Bookings -->
             <div class="nordbooking-card">
                 <div class="nordbooking-card-header">

--- a/functions/initialization.php
+++ b/functions/initialization.php
@@ -212,4 +212,11 @@ if (class_exists('NORDBOOKING\Classes\AvailabilityAjax')) {
         $GLOBALS['nordbooking_availability_ajax']->register_ajax_actions();
     }
 }
+
+// Initialize Service Performance AJAX
+if (class_exists('NORDBOOKING\Classes\ServicePerformance')) {
+    if (!isset($GLOBALS['nordbooking_service_performance'])) {
+        $GLOBALS['nordbooking_service_performance'] = new \NORDBOOKING\Classes\ServicePerformance();
+    }
+}
 ?>

--- a/functions/theme-setup.php
+++ b/functions/theme-setup.php
@@ -340,6 +340,17 @@ if ( is_page_template('templates/booking-form-public.php') || $page_type_for_scr
         // Enqueue the main dashboard stylesheet
         wp_enqueue_style('nordbooking-dashboard-main', NORDBOOKING_THEME_URI . 'assets/css/dashboard-main.css', array('NORDBOOKING-style'), NORDBOOKING_VERSION);
 
+        if ($current_page_slug === 'overview') {
+            wp_enqueue_style('nordbooking-dashboard-overview', NORDBOOKING_THEME_URI . 'assets/css/dashboard-overview.css', array('nordbooking-dashboard-main'), NORDBOOKING_VERSION);
+            wp_enqueue_script('chart-js', 'https://cdn.jsdelivr.net/npm/chart.js', array(), '4.4.1', true);
+            wp_enqueue_script('nordbooking-dashboard-overview-enhanced', NORDBOOKING_THEME_URI . 'assets/js/dashboard-overview-enhanced.js', array('jquery', 'chart-js'), NORDBOOKING_VERSION, true);
+            wp_localize_script('nordbooking-dashboard-overview-enhanced', 'nordbooking_overview_params', [
+                'ajax_url' => admin_url('admin-ajax.php'),
+                'nonce' => wp_create_nonce('nordbooking_ajax_nonce'),
+                'currency_symbol' => get_option('nordbooking_currency_symbol', '$'),
+            ]);
+        }
+
         // Enqueue calendar scripts only on the calendar page.
         if ($current_page_slug === 'calendar') {
             // The main.min.css is correct for styling.


### PR DESCRIPTION
This commit introduces a new widget on the overview page that displays a bar chart showing the performance of different services.

The widget is placed above the "Recent Bookings" section and uses Chart.js to render the chart.

Changes include:
- A new `ServicePerformance` class to handle AJAX requests for service performance data.
- A new AJAX endpoint `nordbooking_get_service_performance`.
- Modifications to `dashboard/page-overview.php` to add the widget's HTML structure.
- Updates to `assets/js/dashboard-overview-enhanced.js` to initialize the chart.
- Updates to `functions/theme-setup.php` to enqueue the necessary scripts and styles for the overview page.