### PR TITLE
feat: Add service performance chart to overview page

### DIFF
--- a/functions/theme-setup.php
+++ b/functions/theme-setup.php
@@ -344,10 +344,12 @@ if ( is_page_template('templates/booking-form-public.php') || $page_type_for_scr
             wp_enqueue_style('nordbooking-dashboard-overview', NORDBOOKING_THEME_URI . 'assets/css/dashboard-overview.css', array('nordbooking-dashboard-main'), NORDBOOKING_VERSION);
             wp_enqueue_script('chart-js', 'https://cdn.jsdelivr.net/npm/chart.js', array(), '4.4.1', true);
             wp_enqueue_script('nordbooking-dashboard-overview-enhanced', NORDBOOKING_THEME_URI . 'assets/js/dashboard-overview-enhanced.js', array('jquery', 'chart-js'), NORDBOOKING_VERSION, true);
+            $stats = function_exists('nordbooking_get_overview_stats') ? nordbooking_get_overview_stats() : [];
             wp_localize_script('nordbooking-dashboard-overview-enhanced', 'nordbooking_overview_params', [
                 'ajax_url' => admin_url('admin-ajax.php'),
                 'nonce' => wp_create_nonce('nordbooking_ajax_nonce'),
                 'currency_symbol' => get_option('nordbooking_currency_symbol', '$'),
+                'stats' => $stats,
             ]);
         }
 


### PR DESCRIPTION
This commit introduces a new widget on the overview page that displays a bar chart showing the performance of different services.

The widget is placed above the "Recent Bookings" section and uses Chart.js to render the chart.

Changes include:
- A new `ServicePerformance` class to handle AJAX requests for service performance data.
- A new AJAX endpoint `nordbooking_get_service_performance`.
- Modifications to `dashboard/page-overview.php` to add the widget's HTML structure.
- Updates to `assets/js/dashboard-overview-enhanced.js` to initialize the chart.
- Refactoring of the stats calculation logic into a new `nordbooking_get_overview_stats` function in `functions/utilities.php`.
- Updates to `functions/theme-setup.php` to enqueue the necessary scripts and styles for the overview page and localize the stats data.